### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-bigquery
+# fluent-plugin-bigquery, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd output plugin to load/insert data into Google BigQuery.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
