### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fluent-plugin-bigquery, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-bigquery
 
-Fluentd output plugin to load/insert data into Google BigQuery.
+[Fluentd](http://fluentd.org) output plugin to load/insert data into Google BigQuery.
 
 * insert data over streaming inserts
   * for continuous real-time insertions, under many limitations


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
