### PR TITLE
output_try_flush_interval_patch is no longer needed.

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -8,8 +8,6 @@ require 'fluent/mixin/plaintextformatter'
 ## TODO: load implementation
 # require 'fluent/plugin/bigquery/load_request_body_wrapper'
 
-require 'fluent/plugin/output_try_flush_interval_patch'
-
 module Fluent
   ### TODO: error classes for each api error responses
   # class BigQueryAPIError < StandardError


### PR DESCRIPTION
`output_try_flush_interval_patch` has merged in Fluentd v0.10.42 (and td-agent v1.1.19 includes Fluentd v0.10.45).

In Fluentd v0.10.46, this patch causes the error "default value specified twice for try_flush_interval".
This validation check is introduced in this commit:
https://github.com/fluent/fluentd/commit/3bf4a4aad5c984778f189e8b25126c6d9400eb1f#diff-f2b658b2bf622c63e8f05e198b3052cfR115

We can avoid this error by removing the default value like below:

``` lib/fluent/plugin/output_try_flush_interval_patch.rb
config_param :try_flush_interval, :float
```

But this patch is no longer needed now, so I think we should remove this.
