### PR TITLE
Fix fetch schema with dynamic table name

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -311,7 +311,8 @@ module Fluent
     end
 
     def fetch_schema
-      table_id = @tablelist[0]
+      table_id_format = @tablelist[0]
+      table_id = generate_table_id(table_id_format, Time.at(Fluent::Engine.now))
       res = client.execute(
         :api_method => @bq.tables.get,
         :parameters => {


### PR DESCRIPTION
In #17, I forgot to consider about table_id_format added by #16.
So when enable both features, it fetch schema fails, because cannot find table.

This PR fix the problem.
