### PR TITLE
support of the timestamp column

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -67,6 +67,7 @@ module Fluent
     config_param :field_integer, :string, :default => nil
     config_param :field_float,   :string, :default => nil
     config_param :field_boolean, :string, :default => nil
+    config_param :field_timestamp, :string, :default => nil
     ### TODO: record field stream inserts doesn't works well?
     ###  At table creation, table type json + field type record -> field type validation fails
     ###  At streaming inserts, schema cannot be specified
@@ -171,6 +172,11 @@ module Fluent
       if @field_boolean
         @field_boolean.split(',').each do |fieldname|
           @fields.register_field fieldname.strip, :boolean
+        end
+      end
+      if @field_timestamp
+        @field_timestamp.split(',').each do |fieldname|
+          @fields.register_field fieldname.strip, :timestamp
         end
       end
 
@@ -445,7 +451,7 @@ module Fluent
       end
 
       def format_one(value)
-        value
+        Time.at(Time.parse(value)).utc.strftime('%s')
       end
     end
 


### PR DESCRIPTION
- support of the timestamp column
- as an example, it can use in "ad delivery" log table.

```
[
    { "name":"time", "type":"timestamp" },           
    { "name":"showed_at", "type":"timestamp" },      
    { "name":"clicked_at", "type":"timestamp" },     
    { "name":"converted_at", "type":"timestamp" },   
    〜 any other column 〜
]
```
