### PR TITLE
Change buffer_chunk_records_limit default value #22

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -24,7 +24,7 @@ module Fluent
     config_set_default :flush_interval, 0.25
     config_set_default :try_flush_interval, 0.05
 
-    config_set_default :buffer_chunk_records_limit, 5000
+    config_set_default :buffer_chunk_records_limit, 500
     config_set_default :buffer_chunk_limit, 1000000
     config_set_default :buffer_queue_limit, 1024
 


### PR DESCRIPTION
BigQuery has a limitation for maximum request per row.
Current default value of fluent-plugin-bigquery is 5,000. It is larger than Google's limitation spec.
Should change default value from 5,000 to 500.
