### PR TITLE
Fix timestamp parsing error

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -451,7 +451,7 @@ module Fluent
       end
 
       def format_one(value)
-        Time.at(Time.parse(value)).utc.strftime('%s')
+        value
       end
     end
 


### PR DESCRIPTION
Fix timestamp parsing error due to parsing kind of timestamp-like string. 
BigQuery automatically converts timestamp with timezone to UTC one, so handling timezone is not required.
- https://twitter.com/hakobera/status/524827024624336897 (in Japanese)
