### PR TITLE
Lock retriable to 1.4.x to fix compatibility issue

### DIFF
--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -21,11 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rr"
 
-  # Lock retriable to 1.4.x. Because 2.X API breaks backward compatibility.
-  # see https://github.com/google/google-api-ruby-client/issues/164
-  spec.add_runtime_dependency "retriable", "~> 1.4" 
-
-  spec.add_runtime_dependency "google-api-client", "~> 0.7.1"
+  spec.add_runtime_dependency "google-api-client", "~> 0.8.0"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   spec.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"


### PR DESCRIPTION
This is patch fix for currently released `google-api-client` gem.
This fix will be fix https://github.com/kaizenplatform/fluent-plugin-bigquery/issues/29

`google-api-client` gem uses `retiable` gem, and it's 2.X API breaks backward compatibility.
So it have to lock retirable to 1.4.x. 

`google-api-client` [master branch](https://github.com/google/google-api-ruby-client/blob/master/google-api-client.gemspec#L33) already [fixed this issue](https://github.com/google/google-api-ruby-client/commit/bb9f607c8e81ded7555d64bd6b4ae49f99142dc1), but it is not released yet.

So until release, temporary lock retiable to 1.4.x at fluent-plugin-bigquery gemspec.

For more detail, see https://github.com/google/google-api-ruby-client/issues/164

Followings are error I got when install fluent-plugin-bigquery to new machine.

```
2014-11-18 05:23:45 +0000 [error]: unexpected error error_class=ArgumentError error=#<ArgumentError: unknown keyword: interval>
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/google-api-client-0.7.1/lib/google/api_client.rb:595:in `execute!'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/google-api-client-0.7.1/lib/google/api_client.rb:330:in `discovery_document'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/google-api-client-0.7.1/lib/google/api_client.rb:375:in `discovered_api'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-bigquery-0.2.5/lib/fluent/plugin/out_bigquery.rb:216:in `start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/plugin/out_copy.rb:50:in `block in start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/plugin/out_copy.rb:49:in `each'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/plugin/out_copy.rb:49:in `start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/match.rb:40:in `start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/engine.rb:263:in `block in start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/engine.rb:262:in `each'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/engine.rb:262:in `start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/engine.rb:213:in `run'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:480:in `run_engine'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:138:in `block in start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:266:in `call'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:266:in `main_process'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:241:in `block in supervise'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:240:in `fork'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:240:in `supervise'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/supervisor.rb:131:in `start'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/lib/fluent/command/fluentd.rb:168:in `<top (required)>'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/bin/fluentd:6:in `<top (required)>'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/bin/fluentd:23:in `load'
  2014-11-18 05:23:45 +0000 [error]: /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
  2014-11-18 05:23:45 +0000 [error]: /usr/sbin/td-agent:7:in `load'
  2014-11-18 05:23:45 +0000 [error]: /usr/sbin/td-agent:7:in `<main>'
```
