### PR TITLE
Update the description about options for high rate inserts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,8 @@ Important options for high rate events are:
     * `out_bigquery` uses these tables for Table Sharding inserts
     * these must have same schema
   * `buffer_chunk_records_limit`
-    * number of records over streaming inserts API call is limited as 100, per second, per table
-    * default average rate limit is 100, and spike rate limit is 1000
-    * `out_bigquery` flushes buffer with 100 records for 1 inserts API call
+    * number of records over streaming inserts API call is limited as 500, per insert or chunk
+    * `out_bigquery` flushes buffer with 500 records for 1 inserts API call
   * `buffer_queue_limit`
     * BigQuery streaming inserts needs very small buffer chunks
     * for high-rate events, `buffer_queue_limit` should be configured with big number

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Important options for high rate events are:
     * 10 or more threads seems good for inserts over internet
     * less threads may be good for Google Compute Engine instances (with low latency for BigQuery)
   * `flush_interval`
-    * `1` is lowest value, without patches on Fluentd v0.10.41 or earlier
-    * see `patches` below
+    * interval between data flushes (default 0.25)
+    * you can set subsecond values such as `0.15` on Fluentd v0.10.42 or later
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Important options for high rate events are:
     * interval between data flushes (default 0.25)
     * you can set subsecond values such as `0.15` on Fluentd v0.10.42 or later
 
+See [Quota policy](https://cloud.google.com/bigquery/streaming-data-into-bigquery#quota)
+section in the Google BigQuery document.
+
 ### Authentication
 
 There are two methods supported to fetch access token for the service account.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Important options for high rate events are:
     * 2 or more tables are available with ',' separator
     * `out_bigquery` uses these tables for Table Sharding inserts
     * these must have same schema
+  * `buffer_chunk_limit`
+    * max size of an insert or chunk (default 1000000 or 1MB)
+    * the max size is limited to 1MB on BigQuery
   * `buffer_chunk_records_limit`
     * number of records over streaming inserts API call is limited as 500, per insert or chunk
     * `out_bigquery` flushes buffer with 500 records for 1 inserts API call


### PR DESCRIPTION
This pull request fixes some issues on the description about options for high rate inserts.

- Adds a description about `buffer_chunk_limit` option, which corresponds to "Maximum data size of all rows, per insert" limit on BigQuery.
- Updates the description about `buffer_chunk_records_limit` option. The default value was already raised to 500.
- Removes a reference to already removed "patches" section, from the description about `flush_interval` option.
- Adds a link to "Quota policy" section in the BigQuery document.