### PR TITLE
Extract Google API accesses from BigQueryOutput and add API error classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ You can set `insert_id_field` option to specify the field to use as `insertId` p
 * support NULLABLE/REQUIRED/REPEATED field options in field list style of configuration
 * OAuth installed application credentials support
 * Google API discovery expiration
-* Error classes
 * check row size limits
 
 ## Authors

--- a/lib/fluent/plugin/bigquery/bigquery_client.rb
+++ b/lib/fluent/plugin/bigquery/bigquery_client.rb
@@ -1,0 +1,138 @@
+require 'json'
+require 'google/api_client'
+require 'google/api_client/client_secrets'
+require 'google/api_client/auth/installed_app'
+require 'google/api_client/auth/compute_service_account'
+
+module Fluent::BigQueryPlugin
+  class BigQueryClient
+    def initialize(attributes = {})
+      attributes.each { |name, value| instance_variable_set("@#{name}", value) }
+    end
+
+    def create_table(name, schema)
+      result =
+        access_api(
+          api_method: bigquery.tables.insert,
+          body_object: {
+            'tableReference' => {
+               'tableId' => name
+            },
+            'schema' => {
+              'fields' => schema
+            }
+          }
+        )
+      handle_error(result) if result.error?
+    end
+
+    def insert(table, rows)
+      result =
+        access_api(
+          api_method: bigquery.tabledata.insert_all,
+          parameters: {
+            'tableId' => table
+          },
+          body_object: {
+            'rows' => rows
+          }
+        )
+      handle_error(result) if result.error?
+    end
+
+    def fetch_schema(table)
+      result =
+        access_api(
+          api_method: bigquery.tables.get,
+          parameters: {
+            'tableId' => table
+          }
+        )
+      handle_error(result) if result.error?
+      JSON.parse(result.body)['schema']['fields']
+    end
+
+    def load
+      # https://developers.google.com/bigquery/loading-data-into-bigquery#loaddatapostrequest
+      raise NotImplementedError # TODO
+    end
+
+    private
+
+    def access_api(params = {})
+      params[:parameters] ||= {}
+      params[:parameters]['projectId'] ||= @project
+      params[:parameters]['datasetId'] ||= @dataset
+      client.execute(params)
+    end
+
+    def bigquery
+      # TODO: refresh with specified expiration
+      @bigquery ||= client.discovered_api('bigquery', 'v2')
+    end
+
+    def handle_error(result)
+      @client = nil # clear cashed client when errors occur
+      error =
+        case result.status
+        when 404      then NotFound
+        when 409      then Conflict
+        when 400..499 then ClientError
+        when 500..599 then ServerError
+        else UnexpectedError
+        end
+      fail error, result.error_message
+    end
+
+    def client
+      @client = nil if expired?
+      unless @client
+        @client = Google::APIClient.new(
+          application_name: 'Fluentd BigQuery plugin',
+          application_version: Fluent::BigQueryPlugin::VERSION
+        )
+        authorize_client
+        @expiration = Time.now + 1800
+      end
+      @client
+    end
+
+    def expired?
+      @expiration && @expiration < Time.now
+    end
+
+    def authorize_client
+      case @auth_method
+      when 'private_key'
+        asserter =
+          Google::APIClient::JWTAsserter.new(
+            @email,
+            'https://www.googleapis.com/auth/bigquery',
+            Google::APIClient::PKCS12.load_key(@private_key_path, @private_key_passphrase)
+          )
+        @client.authorization = asserter.authorize
+      when 'compute_engine'
+        auth = Google::APIClient::ComputeServiceAccount.new
+        auth.fetch_access_token!
+        @client.authorization = auth
+      end
+    end
+
+    # def client_oauth # not implemented
+    #   raise NotImplementedError, "OAuth needs browser authentication..."
+    #
+    #   client = Google::APIClient.new(
+    #     application_name: 'Example Ruby application',
+    #     application_version: '1.0.0'
+    #   )
+    #   bigquery = client.discovered_api('bigquery', 'v2')
+    #   flow = Google::APIClient::InstalledAppFlow.new(
+    #     client_id: @client_id
+    #     client_secret: @client_secret
+    #     scope: ['https://www.googleapis.com/auth/bigquery']
+    #   )
+    #   client.authorization = flow.authorize # browser authentication !
+    #   client
+    # end
+  end
+end

--- a/lib/fluent/plugin/bigquery/errors.rb
+++ b/lib/fluent/plugin/bigquery/errors.rb
@@ -1,0 +1,23 @@
+module Fluent::BigQueryPlugin
+  class BigQueryAPIError < StandardError
+  end
+
+  # HTTP 4xx Client Error
+  class ClientError < BigQueryAPIError
+  end
+
+  # HTTP 404 Not Found
+  class NotFound < ClientError
+  end
+
+  # HTTP 409 Conflict
+  class Conflict < ClientError
+  end
+
+  # HTTP 5xx Server Error
+  class ServerError < BigQueryAPIError
+  end
+
+  class UnexpectedError < BigQueryAPIError
+  end
+end

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -12,10 +12,6 @@ require 'fluent/plugin/bigquery/bigquery_client'
 # require 'fluent/plugin/bigquery/load_request_body_wrapper'
 
 module Fluent
-  ### TODO: error classes for each api error responses
-  # class BigQueryAPIError < StandardError
-  # end
-
   class BigQueryOutput < BufferedOutput
     Fluent::Plugin.register_output('bigquery', self)
 

--- a/test/plugin/test_bigquery_client.rb
+++ b/test/plugin/test_bigquery_client.rb
@@ -1,0 +1,147 @@
+require 'helper'
+
+class BigQueryClientTest < Test::Unit::TestCase
+  def setup
+    @client = Fluent::BigQueryPlugin::BigQueryClient.new(
+      project:                '1234567890',
+      dataset:                'my_dataset',
+      email:                  '1234567890@developer.gserviceaccount.com',
+      private_key_path:       '/path/to/keyfile.p12',
+      private_key_passphrase: 'itsasecret',
+      auth_method:            'private_key'
+    )
+  end
+
+  def test_initialize
+    actual   = @client.instance_variables
+    expected = [:@project, :@dataset, :@email, :@private_key_path, :@private_key_passphrase, :@auth_method]
+    assert { actual.sort == expected.sort }
+  end
+
+  def test_create_table
+    params = {
+      api_method: 'create_table',
+      body_object: {
+        'tableReference' => {
+          'tableId' => 'my_table'
+        },
+        'schema' => {
+          'fields' => [
+            {'name' => 'foo', 'type' => 'timestamp'},
+            {'name' => 'bar', 'type' => 'string'}
+          ]
+        }
+      },
+      parameters: {
+        'projectId' => '1234567890',
+        'datasetId' => 'my_dataset'
+      }
+    }
+    auth = Object.new
+    mock(client = Object.new) do |client|
+      client.discovered_api('bigquery', 'v2') { mock!.tables.mock!.insert { 'create_table' } }
+      client.execute(params) { mock(Object.new).error? { false } }
+      client.authorization = auth
+    end
+    mock(Google::APIClient).new.with_any_args { client }
+    mock(Google::APIClient::JWTAsserter).new.with_any_args { mock(Object.new).authorize { auth } }
+    mock(Google::APIClient::PKCS12).load_key('/path/to/keyfile.p12', 'itsasecret')
+    schema = [{'name' => 'foo', 'type' => 'timestamp'}, {'name' => 'bar', 'type' => 'string'}]
+    assert { @client.create_table('my_table', schema).nil? }
+  end
+
+  def test_insert
+    params = {
+      api_method: 'insert_all',
+      parameters: {
+        'projectId' => '1234567890',
+        'datasetId' => 'my_dataset',
+        'tableId'   => 'my_table'
+      },
+      body_object: {
+        'rows' => [
+          { 'json' => { 'a' => 'b' } },
+          { 'json' => { 'b' => 'c' } }
+        ]
+      }
+    }
+    auth = Object.new
+    mock(client = Object.new) do |client|
+      client.discovered_api('bigquery', 'v2') { mock!.tabledata.mock!.insert_all { 'insert_all' } }
+      client.execute(params) { mock(Object.new).error? { false } }
+      client.authorization = auth
+    end
+    mock(Google::APIClient).new.with_any_args { client }
+    mock(Google::APIClient::JWTAsserter).new.with_any_args { mock(Object.new).authorize { auth } }
+    mock(Google::APIClient::PKCS12).load_key('/path/to/keyfile.p12', 'itsasecret')
+    rows = [{'json' => {'a' => 'b'}}, {'json' => {'b' => 'c'}}]
+    assert { @client.insert('my_table', rows).nil? }
+  end
+
+  def test_fetch_schema
+    params = {
+      api_method: 'tables_get',
+      parameters: {
+        'tableId'   => 'my_table',
+        'projectId' => '1234567890',
+        'datasetId' => 'my_dataset'
+      }
+    }
+    result_body = JSON.generate(
+      {
+        schema: {
+          fields: [
+            { name: 'time', type: 'TIMESTAMP' },
+            { name: 'tty',  type: 'STRING'    }
+          ]
+        }
+      }
+    )
+    auth = Object.new
+    mock(result = Object.new) do |result|
+      result.error? { false }
+      result.body   { result_body }
+    end
+    mock(client = Object.new) do |client|
+      client.discovered_api('bigquery', 'v2') { mock!.tables.mock!.get { 'tables_get' } }
+      client.execute(params) { result }
+      client.authorization = auth
+    end
+    mock(Google::APIClient).new.with_any_args { client }
+    mock(Google::APIClient::JWTAsserter).new.with_any_args { mock(Object.new).authorize { auth } }
+    mock(Google::APIClient::PKCS12).load_key('/path/to/keyfile.p12', 'itsasecret')
+    expected = [
+      { 'name' => 'time', 'type' => 'TIMESTAMP' },
+      { 'name' => 'tty',  'type' => 'STRING'    }
+    ]
+    assert { @client.fetch_schema('my_table') == expected }
+  end
+
+  def test_errors
+    errors = [
+      { code: 404, klass: Fluent::BigQueryPlugin::NotFound        },
+      { code: 409, klass: Fluent::BigQueryPlugin::Conflict        },
+      { code: 403, klass: Fluent::BigQueryPlugin::ClientError     },
+      { code: 503, klass: Fluent::BigQueryPlugin::ServerError     },
+      { code: 301, klass: Fluent::BigQueryPlugin::UnexpectedError }
+    ]
+    errors.each do |error|
+      auth = Object.new
+      mock(result = Object.new) do |result|
+        result.error?        { true }
+        result.status        { error[:code] }
+        result.error_message { 'this is an error message' }
+      end
+      mock(client = Object.new) do |client|
+        client.execute.with_any_args { result }
+        client.authorization = auth
+      end
+      mock(@client).bigquery { mock!.tabledata.mock!.insert_all }
+      mock(Google::APIClient).new.with_any_args { client }
+      mock(Google::APIClient::JWTAsserter).new.with_any_args { mock(Object.new).authorize { auth } }
+      mock(Google::APIClient::PKCS12).load_key('/path/to/keyfile.p12', 'itsasecret')
+      rows = [{'json' => {'a' => 'b'}}, {'json' => {'b' => 'c'}}]
+      assert_raise(error[:klass]) { @client.insert('my_table', rows) }
+    end
+  end
+end

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -54,10 +54,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       time_format %s
       time_field  time
 
-      field_integer time  , status , bytes 
+      field_integer time  , status , bytes
       field_string  _log_name, vhost, path, method, protocol, agent, referer, remote.host, remote.ip, remote.user
-      field_float   requesttime 
-      field_boolean bot_access , loginsession 
+      field_float   requesttime
+      field_boolean bot_access , loginsession
     ])
     fields = driver.instance.instance_eval{ @fields }
 
@@ -251,6 +251,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       field_integer metadata.time
       field_string  metadata.node,log
     CONFIG
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -330,6 +331,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "apache.schema")}
       field_integer time
     CONFIG
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -370,6 +372,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "sudo.schema")}
       field_integer time
     CONFIG
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -414,6 +417,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     stub(Fluent::BigQueryPlugin::BigQueryClient).new do
       mock(Object.new).fetch_schema('foo') { sudo_schema_response }
     end
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -428,7 +432,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     assert fields["tty"]
     assert_equal :string, fields["tty"].type
     assert_equal :nullable, fields["tty"].mode
-    
+
     assert fields["pwd"]
     assert_equal :string, fields["pwd"].type
     assert_equal :required, fields["pwd"].mode
@@ -480,6 +484,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     stub(Fluent::BigQueryPlugin::BigQueryClient).new do
       mock(Object.new).fetch_schema(table) { sudo_schema_response }
     end
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -494,7 +499,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     assert fields["tty"]
     assert_equal :string, fields["tty"].type
     assert_equal :nullable, fields["tty"].mode
-    
+
     assert fields["pwd"]
     assert_equal :string, fields["pwd"].type
     assert_equal :required, fields["pwd"].mode
@@ -533,6 +538,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       insert_id_field uuid
       field_string uuid
     CONFIG
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -569,6 +575,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       insert_id_field data.uuid
       field_string data.uuid
     CONFIG
+
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -601,6 +608,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "sudo.schema")}
       field_integer time
     CONFIG
+
     driver.instance.start
     assert_raises(RuntimeError.new("Required field user cannot be null")) do
       driver.instance.format_stream("my.tag", [input])
@@ -677,6 +685,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       auto_create_table true
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "apache.schema")}
     CONFIG
+
     chunk = Fluent::MemoryBufferChunk.new("my.tag")
     chunk << message.to_msgpack
 

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -29,23 +29,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
     Fluent::Test::OutputTestDriver.new(Fluent::BigQueryOutput).configure(conf)
   end
 
-  def stub_client(driver)
-    stub(client = Object.new) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-      yield expect if defined?(yield)
-    end
-    stub(driver.instance).client { client }
-    client
-  end
-
-  def mock_client(driver)
-    mock(client = Object.new) do |expect|
-      yield expect
-    end
-    stub(driver.instance).client { client }
-    client
-  end
-
   def test_configure_table
     driver = create_driver
     assert_equal driver.instance.table, 'foo'
@@ -58,21 +41,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
     assert_raise(Fluent::ConfigError, "'table' or 'tables' must be specified, and both are invalid") {
       create_driver(CONFIG + "tables foo,bar")
     }
-  end
-
-  def test_configure_auth
-    key = stub!
-    mock(Google::APIClient::PKCS12).load_key('/path/to/key', 'notasecret') { key }
-    authorization = Object.new
-    asserter = mock!.authorize { authorization }
-    mock(Google::APIClient::JWTAsserter).new('foo@bar.example', API_SCOPE, key) { asserter }
-
-    mock.proxy(Google::APIClient).new.with_any_args { 
-      mock!.__send__(:authorization=, authorization) {}
-    }
-
-    driver = create_driver(CONFIG)
-    driver.instance.client()
   end
 
   def test_configure_fieldname_stripped
@@ -197,9 +165,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
     }
 
     driver = create_driver(CONFIG)
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-    end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -243,7 +208,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
         time_field  time
         #{type}     time
       CONFIG
-      stub_client(driver)
 
       driver.instance.start
       buf = driver.instance.format_stream("my.tag", [input])
@@ -287,7 +251,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
       field_integer metadata.time
       field_string  metadata.node,log
     CONFIG
-    stub_client(driver)
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -367,9 +330,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "apache.schema")}
       field_integer time
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-    end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -410,9 +370,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "sudo.schema")}
       field_integer time
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-    end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -453,21 +410,9 @@ class BigQueryOutputTest < Test::Unit::TestCase
       fetch_schema true
       field_integer time
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { mock!.tables.mock!.get { Object.new } }
-      expect.execute(
-        :api_method => anything,
-        :parameters => {
-          'projectId' => 'yourproject_id',
-          'datasetId' => 'yourdataset_id',
-          'tableId' => 'foo'
-        }
-      ) {
-        s = stub!
-        s.success? { true }
-        s.body { JSON.generate(sudo_schema_response) }
-        s
-      }
+
+    stub(Fluent::BigQueryPlugin::BigQueryClient).new do
+      mock(Object.new).fetch_schema('foo') { sudo_schema_response }
     end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
@@ -530,21 +475,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       fetch_schema true
       field_integer time
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { mock!.tables.mock!.get { Object.new } }
-      expect.execute(
-        :api_method => anything,
-        :parameters => {
-          'projectId' => 'yourproject_id',
-          'datasetId' => 'yourdataset_id',
-          'tableId' => now.strftime('foo_%Y_%m_%d')
-        }
-      ) {
-        s = stub!
-        s.success? { true }
-        s.body { JSON.generate(sudo_schema_response) }
-        s
-      }
+
+    table = now.strftime('foo_%Y_%m_%d')
+    stub(Fluent::BigQueryPlugin::BigQueryClient).new do
+      mock(Object.new).fetch_schema(table) { sudo_schema_response }
     end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
@@ -599,9 +533,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
       insert_id_field uuid
       field_string uuid
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-    end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -638,9 +569,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
       insert_id_field data.uuid
       field_string data.uuid
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-    end
     driver.instance.start
     buf = driver.instance.format_stream("my.tag", [input])
     driver.instance.shutdown
@@ -673,9 +601,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "sudo.schema")}
       field_integer time
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { stub! }
-    end
     driver.instance.start
     assert_raises(RuntimeError.new("Required field user cannot be null")) do
       driver.instance.format_stream("my.tag", [input])
@@ -685,25 +610,12 @@ class BigQueryOutputTest < Test::Unit::TestCase
 
   def test_write
     entry = {"json" => {"a" => "b"}}, {"json" => {"b" => "c"}}
-    driver = create_driver(CONFIG)
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") { mock!.tabledata.mock!.insert_all { Object.new } }
-      expect.execute(
-        :api_method => anything,
-        :parameters => {
-          'projectId' => 'yourproject_id',
-          'datasetId' => 'yourdataset_id',
-          'tableId' => 'foo',
-        },
-        :body_object => {
-          'rows' => [entry]
-        }
-      ) { stub!.success? { true } }
-    end
+    stub(Fluent::BigQueryPlugin::BigQueryClient).new { mock(Object.new).insert('foo', [entry]) }
 
     chunk = Fluent::MemoryBufferChunk.new("my.tag")
     chunk << entry.to_msgpack
 
+    driver = create_driver(CONFIG)
     driver.instance.start
     driver.instance.write(chunk)
     driver.instance.shutdown
@@ -744,6 +656,13 @@ class BigQueryOutputTest < Test::Unit::TestCase
         },
       }
     }
+    schema = JSON.parse(File.read(File.join(File.dirname(__FILE__), "testdata", "apache.schema")))
+    stub(Fluent::BigQueryPlugin::BigQueryClient).new do |client|
+      mock(client).insert('foo', [message]) do
+        raise Fluent::BigQueryPlugin::NotFound, "Not Found: Table yourproject_id:yourdataset_id.foo"
+      end
+      mock(client).create_table('foo', schema)
+    end
 
     driver = create_driver(<<-CONFIG)
       table foo
@@ -758,57 +677,11 @@ class BigQueryOutputTest < Test::Unit::TestCase
       auto_create_table true
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "apache.schema")}
     CONFIG
-    mock_client(driver) do |expect|
-      expect.discovered_api("bigquery", "v2") {
-        mock! {
-          tables.mock!.insert { Object.new }
-          tabledata.mock!.insert_all { Object.new }
-        }
-      }
-      expect.execute(
-        :api_method => anything,
-        :parameters => {
-          'projectId' => 'yourproject_id',
-          'datasetId' => 'yourdataset_id',
-          'tableId' => 'foo'
-        },
-        :body_object => {
-          "rows" => [ message ]
-        }
-      ) {
-        s = stub!
-        s.success? { false }
-        s.body { JSON.generate({
-          'error' => { "code" => 404, "message" => "Not Found: Table yourproject_id:yourdataset_id.foo" }
-        }) }
-        s.status { 404 }
-        s
-      }
-      expect.execute(
-        :api_method => anything,
-        :parameters => {
-          'projectId' => 'yourproject_id',
-          'datasetId' => 'yourdataset_id',
-        },
-        :body_object => {
-          'tableReference' => {
-            'tableId' => 'foo',
-          },
-          'schema' => {
-            'fields' => JSON.parse(File.read(File.join(File.dirname(__FILE__), "testdata", "apache.schema")))
-          }
-        }
-      ) {
-        s = stub!
-        s.success? { true }
-        s
-      }
-    end
     chunk = Fluent::MemoryBufferChunk.new("my.tag")
     chunk << message.to_msgpack
 
     driver.instance.start
-    assert_raise(RuntimeError) {
+    assert_raise(Fluent::BigQueryPlugin::NotFound) {
       driver.instance.write(chunk)
     }
     driver.instance.shutdown
@@ -817,36 +690,32 @@ class BigQueryOutputTest < Test::Unit::TestCase
   private
 
   def sudo_schema_response
-    {
-      schema: {
-        fields: [
-          {
-            name: "time",
-            type: "TIMESTAMP",
-            mode: "REQUIRED"
-          },
-          {
-            name: "tty",
-            type: "STRING",
-            mode: "NULLABLE"
-          },
-          {
-            name: "pwd",
-            type: "STRING",
-            mode: "REQUIRED"
-          },
-          {
-            name: "user",
-            type: "STRING",
-            mode: "REQUIRED"
-          },
-          {
-            name: "argv",
-            type: "STRING",
-            mode: "REPEATED"
-          }
-        ]
+    [
+      {
+        'name' => 'time',
+        'type' => 'TIMESTAMP',
+        'mode' => 'REQUIRED'
+      },
+      {
+        'name' => 'tty',
+        'type' => 'STRING',
+        'mode' => 'NULLABLE'
+      },
+      {
+        'name' => 'pwd',
+        'type' => 'STRING',
+        'mode' => 'REQUIRED'
+      },
+      {
+        'name' => 'user',
+        'type' => 'STRING',
+        'mode' => 'REQUIRED'
+      },
+      {
+        'name' => 'argv',
+        'type' => 'STRING',
+        'mode' => 'REPEATED'
       }
-    }
+    ]
   end
 end


### PR DESCRIPTION
It looked like BigQueryOutput was in violation of the Single Responsibility Principle (SRP) because it accesses the Google API a lot, in addition to its responsibilities as a BufferedOutput. So I extracted a class to hold the web access logic.

I also fulfilled a [TODO to add error classes for each API](https://github.com/kaizenplatform/fluent-plugin-bigquery/blob/b76a37ce9c07c3d5dbd34827842ddea742ce94cc/lib/fluent/plugin/out_bigquery.rb#L12-14).
- [x] Add API error classes
- [x] Update README
- [x] Add BigQuery API client class and its test cases
- [x] Fix BigQueryOutput
- [x] Fix existing test cases
