### PR TITLE
Implement BigQuery load job

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ Important options for high rate events are:
 See [Quota policy](https://cloud.google.com/bigquery/streaming-data-into-bigquery#quota)
 section in the Google BigQuery document.
 
+### Load
+
+Sample load configuration.
+
+```apache
+<match dummy>
+  type bigquery
+
+  ...
+
+  method load
+
+  buffer_type file            # required
+  buffer_path /path/to/file   # required
+  buffer_chunk_limit 256m
+  buffer_queue_limit 64
+  flush_interval 10m          # Daily limit: 1,000 load jobs per table per day (including failures),
+                              # 10,000 load jobs per project per day (including failures)
+  retry_wait 60s
+  retry_limit 7
+  sync_load_job true          # wait until a load job is done (default)
+</match>
+```
+
 ### Authentication
 
 There are two methods supported to fetch access token for the service account.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Sample load configuration.
   retry_wait 60s
   retry_limit 7
   sync_load_job true          # wait until a load job is done (default)
+  request_timeout 120         # HTTP request timeout (default: 60)
 </match>
 ```
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -381,9 +381,9 @@ module Fluent
         res_obj = extract_response_obj(res.body)
         if res.success?
           if res_obj['status']['state'] == 'DONE'
+            File.unlink wait_load_job_file if File.exist? wait_load_job_file
             unless res_obj['status']['errorResult']
               log.info "DONE jobs.insert (load) API", project_id: @project, dataset: @dataset, table: table_id, job_id: job_id, chunk_path: chunk.path
-              File.unlink wait_load_job_file if File.exist? wait_load_job_file
               return
             else
               message = res_obj['status']['errorResult']['message']

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -96,6 +96,7 @@ module Fluent
 
     #config_param :load_configuration, :hash, default: {} # use v1config (for now, comment out)
     config_param :sync_load_job, :bool, default: true # wait until load job is done
+    config_param :request_timeout, :integer, default: 60
 
     config_param :row_size_limit, :integer, default: 100*1000 # < 100KB # configurable in google ?
     # config_param :insert_size_limit, :integer, default: 1000**2 # < 1MB
@@ -220,7 +221,8 @@ module Fluent
 
       client = Google::APIClient.new(
         application_name: 'Fluentd BigQuery plugin',
-        application_version: Fluent::BigQueryPlugin::VERSION
+        application_version: Fluent::BigQueryPlugin::VERSION,
+        faraday_option: { 'timeout' => @request_timeout }
       )
 
       case @auth_method

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -331,6 +331,7 @@ module Fluent
         }
         @load_configuration['schema'] = { 'fields' => @fields.to_a }
         @load_configuration['sourceFormat'] = 'NEWLINE_DELIMITED_JSON'
+        @load_configuration['writeDisposition'] = 'WRITE_APPEND'
 
         buf_file = File.open(chunk.path)
         media = Google::APIClient::UploadIO.new(buf_file, 'application/octet-stream')


### PR DESCRIPTION
Hi,

I've implemented BigQuery load job.
(Because streaming inserts cost $0.01 per 100,000 rows from 2015.)

So, please check it. Implementation points are below.

Implementation points:
- Suported buffer_type is "file" only.
- A buffer file format is NEWLINED_DELIMITED_JSON. (https://cloud.google.com/bigquery/preparing-data-for-bigquery#dataformats)
- You can select sync/async mode using sync_load_job option.
  - sync mode (default): Don't dequeue from buffer_queue until a load job state is done. A load job state is checked at retry interval of fluentd.
  - async mode: Dequeue from buffer_queue as soon as a load job is registered in BigQuery. A load job state is not checked.

If you have any opinions, please let me know.

Best regards.