### PR TITLE
Handling insert errors

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -298,6 +298,8 @@ module Fluent
       if res.success?
         unless res_obj["insertErrors"].nil? or res_obj["insertErrors"].empty?
           if res_obj["insertErrors"].size >= rows.size
+            stopped, errors = res_obj["insertErrors"].partition { |ie| (ie["errors"] || []).all? { |e| e["reason"] == "stopped" } }
+            puts "insert errors", :errors => errors, :stopped_count => stopped.count
             raise "failed to insert into bigquery" # TODO: error class
           else
             log.error "insert error", :insert_errors => res_obj["insertErrors"]

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -298,8 +298,12 @@ module Fluent
       if res.success?
         unless res_obj["insertErrors"].nil? or res_obj["insertErrors"].empty?
           if res_obj["insertErrors"].size >= rows.size
-            stopped, errors = res_obj["insertErrors"].partition { |ie| (ie["errors"] || []).all? { |e| e["reason"] == "stopped" } }
-            puts "insert errors", :errors => errors, :stopped_count => stopped.count
+            begin
+              stopped, errors = res_obj["insertErrors"].partition { |ie| (ie["errors"] || []).all? { |e| e["reason"] == "stopped" } }
+              log.warn "insert error", :errors => errors, :stopped_count => stopped.count
+            rescue
+              log.warn "insert error", :insert_errors => res_obj["insertErrors"]
+            end
             raise "failed to insert into bigquery" # TODO: error class
           else
             log.error "insert error", :insert_errors => res_obj["insertErrors"]

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -736,17 +736,15 @@ class BigQueryOutputTest < Test::Unit::TestCase
           'insertErrors' => [
             {
               'index' => 0,
-              'errors' => {
-                'reason' => 'any reason',
-                'message' => 'any message'
-              }
+              'errors' => [{
+                'reason' => 'any reason'
+              }]
             },
             {
               'index' => 1,
-              'errors' => {
-                'reason' => 'any reason',
-                'message' => 'any message'
-              }
+              'errors' => [{
+                'reason' => 'stopped'
+              }]
             },
           ]
         }) }

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -698,7 +698,11 @@ class BigQueryOutputTest < Test::Unit::TestCase
         :body_object => {
           'rows' => [entry]
         }
-      ) { stub!.success? { true } }
+      ) {
+        s = stub!
+        s.success? { true }
+        s.body { JSON.generate({'kind' => 'bigquery#tableDataInsertAllRequest'}) }
+      }
     end
 
     chunk = Fluent::MemoryBufferChunk.new("my.tag")
@@ -706,6 +710,56 @@ class BigQueryOutputTest < Test::Unit::TestCase
 
     driver.instance.start
     driver.instance.write(chunk)
+    driver.instance.shutdown
+  end
+
+  def test_write_and_insert_errors
+    entry = {"json" => {"a" => "b"}}, {"json" => {"b" => "c"}}
+    driver = create_driver(CONFIG)
+    mock_client(driver) do |expect|
+      expect.discovered_api("bigquery", "v2") { mock!.tabledata.mock!.insert_all { Object.new } }
+      expect.execute(
+        :api_method => anything,
+        :parameters => {
+          'projectId' => 'yourproject_id',
+          'datasetId' => 'yourdataset_id',
+          'tableId' => 'foo',
+        },
+        :body_object => {
+          'rows' => [entry]
+        }
+      ) {
+        s = stub!
+        s.success? { true }
+        s.body { JSON.generate({
+          'kind' => 'bigquery#tableDataInsertAllRequest',
+          'insertErrors' => [
+            {
+              'index' => 0,
+              'errors' => {
+                'reason' => 'any reason',
+                'message' => 'any message'
+              }
+            },
+            {
+              'index' => 1,
+              'errors' => {
+                'reason' => 'any reason',
+                'message' => 'any message'
+              }
+            },
+          ]
+        }) }
+      }
+    end
+
+    chunk = Fluent::MemoryBufferChunk.new("my.tag")
+    chunk << entry.to_msgpack
+
+    driver.instance.start
+    assert_raise(RuntimeError) {
+      driver.instance.write(chunk)
+    }
     driver.instance.shutdown
   end
 


### PR DESCRIPTION
When sending invalid value to BigQuery, it returns "insertErrors" field in response body with status 200.
Current plugin seems not to be able to detect this error.

see: https://cloud.google.com/bigquery/docs/reference/v2/tabledata/insertAll

This patch will raise error when all records are in "insertErrors" field, and the records may be output secondary after retrying.
Though undocumented, BigQuery seems treat all records as "insert error" even if only one of records in a request is invalid.
ex. sending 3 records with BigQuery API `insertAll` :
```
[
  {time: "2015-03-18 00:00:00 UTC"},
  {time: "2015-03-18 01:00:00 INVALID_TIME_ZONE"},
  {time: "2015-03-18 02:00:00 UTC"}
]
```
and it returns:
```
{
 "kind": "bigquery#tableDataInsertAllResponse",
 "insertErrors": [
  {
   "index": 1,
   "errors": [
    {
     "reason": "invalid",
     "message": "Unrecognized timezone: INVALID_TIME_ZONE"
    }
   ]
  },
  {
   "index": 0,
   "errors": [
    {
     "reason": "stopped"
    }
   ]
  },
  {
   "index": 2,
   "errors": [
    {
     "reason": "stopped"
    }
   ]
  }
 ]
}
```