### PR TITLE
check error message with case insensitive regexp.

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -300,7 +300,7 @@ module Fluent
         res_obj = extract_response_obj(res.body)
         message = res_obj['error']['message'] || res.body
         if res_obj
-          if @auto_create_table and res_obj and res_obj['error']['code'] == 404 and /Not Found: Table/ =~ message.to_s
+          if @auto_create_table and res_obj and res_obj['error']['code'] == 404 and /Not Found: Table/i =~ message.to_s
             # Table Not Found: Auto Create Table
             create_table(table_id)
           end

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -779,7 +779,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
         s = stub!
         s.success? { false }
         s.body { JSON.generate({
-          'error' => { "code" => 404, "message" => "Not Found: Table yourproject_id:yourdataset_id.foo" }
+          'error' => { "code" => 404, "message" => "Not found: Table yourproject_id:yourdataset_id.foo" }
         }) }
         s.status { 404 }
         s


### PR DESCRIPTION
It seems that BigQuery API [tabledata.insertAll](https://cloud.google.com/bigquery/docs/reference/v2/tabledata/insertAll) returns error message slightly different from before if table is not found.

"Not Found: Table xxx" -> "Not found: Table xxx"

This change fixes failure of table not found error detection.