### PR TITLE
change Faraday.default_adapter from Net::Http to HTTPClient

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -191,6 +191,8 @@ module Fluent
       else
         @get_insert_id = nil
       end
+
+      Faraday.default_adapter = :httpclient
     end
 
     def start


### PR DESCRIPTION
Sometimes, `fluent-plugin-bigquery` out `Broken Pipe Error`, becauseof below problem.
see: https://github.com/google/google-api-ruby-client/issues/69
see: http://stackoverflow.com/questions/24201842/uploading-a-video-to-youtube-using-youtube-data-api-broken-pipe-errnoepipe

So, I change `Faraday.default_adapter` from `Net::Http` to `HTTPClient`.
Would you like to review this PR? :bow: 