### PR TITLE
Fix handling auto create table

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -270,7 +270,7 @@ module Fluent
           rescue => e
             log.warn "Parse error: google api error response body", :body => res.body
           end
-          if res_obj and res_obj['code'] == 409 and /Already Exists:/ =~ message
+          if res_obj and res_obj['error']['code'] == 409 and /Already Exists:/ =~ message
             # ignore 'Already Exists' error
             return
           end

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -303,6 +303,7 @@ module Fluent
           if @auto_create_table and res_obj and res_obj['error']['code'] == 404 and /Not Found: Table/i =~ message.to_s
             # Table Not Found: Auto Create Table
             create_table(table_id)
+            raise "table created. send rows next time."
           end
         end
         log.error "tabledata.insertAll API", project_id: @project, dataset: @dataset, table: table_id, code: res.status, message: message


### PR DESCRIPTION
Clean up `/var/log/td-agent/td-agent.log`

## Before
```
2015-07-10 03:34:27 +0900 [error]: tabledata.insertAll API project_id="PROJECT_ID" dataset="DATASET" table="nginx_access_201507" code=404 message="Not found: Table PROJECT_ID:DATASET.nginx_access_201507"
2015-07-10 03:34:27 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-10 03:34:27 +0900 error_class="RuntimeError" error="failed to insert into bigquery" plugin_id="object:3f8748386f44"
2015-07-10 03:34:28 +0900 [error]: tables.insert API project_id="PROJECT_ID" dataset="DATASET" table="nginx_access_201507" code=409 message="Already Exists: Table PROJECT_ID:DATASET.nginx_access_201507"
2015-07-10 03:34:28 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-10 03:34:29 +0900 error_class="RuntimeError" error="failed to create table in bigquery" plugin_id="object:3f8748386f44"
(loop...)
```
## After
```
2015-07-14 22:15:03 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-14 22:15:02 +0900 error_class="RuntimeError" error="table created. send rows next time." plugin_id="object:3fc60fb2a524"
```