### PR TITLE
Added record's key replacement function

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -78,7 +78,7 @@ module Fluent
 
     REGEXP_MAX_NUM = 10
     config_param :replace_record_key, :bool, default: false
-    (1..REGEXP_MAX_NUM).each {|i| config_param :"regexp#{i}", :string, default: nil }
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"replace_record_regexp#{i}", :string, default: nil }
 
     config_param :time_format, :string, default: nil
     config_param :localtime, :bool, default: nil
@@ -174,10 +174,10 @@ module Fluent
 
       @regexps = {}
       (1..REGEXP_MAX_NUM).each do |i|
-        next unless conf["regexp#{i}"]
-        regexp, replacement = conf["regexp#{i}"].split(/ /, 2)
-        raise ConfigError, "regexp#{i} does not contain 2 parameters" unless replacement
-        raise ConfigError, "regexp#{i} contains a duplicated key, #{regexp}" if @regexps[regexp]
+        next unless conf["replace_record_regexp#{i}"]
+        regexp, replacement = conf["replace_record_regexp#{i}"].split(/ /, 2)
+        raise ConfigError, "replace_record_regexp#{i} does not contain 2 parameters" unless replacement
+        raise ConfigError, "replace_record_regexp#{i} contains a duplicated key, #{regexp}" if @regexps[regexp]
         @regexps[regexp] = replacement
       end
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -78,7 +78,7 @@ module Fluent
 
     REGEXP_MAX_NUM = 10
     config_param :replace_record_key, :bool, default: false
-    (1..REGEXP_MAX_NUM).each {|i| config_param :"replace_record_regexp#{i}", :string, default: nil }
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"replace_record_key_regexp#{i}", :string, default: nil }
 
     config_param :time_format, :string, default: nil
     config_param :localtime, :bool, default: nil
@@ -174,10 +174,10 @@ module Fluent
 
       @regexps = {}
       (1..REGEXP_MAX_NUM).each do |i|
-        next unless conf["replace_record_regexp#{i}"]
-        regexp, replacement = conf["replace_record_regexp#{i}"].split(/ /, 2)
-        raise ConfigError, "replace_record_regexp#{i} does not contain 2 parameters" unless replacement
-        raise ConfigError, "replace_record_regexp#{i} contains a duplicated key, #{regexp}" if @regexps[regexp]
+        next unless conf["replace_record_key_regexp#{i}"]
+        regexp, replacement = conf["replace_record_key_regexp#{i}"].split(/ /, 2)
+        raise ConfigError, "replace_record_key_regexp#{i} does not contain 2 parameters" unless replacement
+        raise ConfigError, "replace_record_key_regexp#{i} contains a duplicated key, #{regexp}" if @regexps[regexp]
         @regexps[regexp] = replacement
       end
 

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -683,6 +683,54 @@ class BigQueryOutputTest < Test::Unit::TestCase
     driver.instance.shutdown
   end
 
+  def test_replace_record_key
+    now = Time.now
+    input = [
+      now,
+      {
+        "vhost" => :bar,
+        "@referer" => "http://referer.example",
+        "bot_access" => true,
+        "login-session" => false
+      }
+    ]
+    expected = {
+      "json" => {
+        "time" => now.to_i,
+        "vhost" => "bar",
+        "referer" => "http://referer.example",
+        "bot_access" => true,
+        "login_session" => false
+      }
+    }
+
+    driver = create_driver(<<-CONFIG)
+      table foo
+      email foo@bar.example
+      private_key_path /path/to/key
+      project yourproject_id
+      dataset yourdataset_id
+
+      replace_record_key true
+      regexp1 - _
+
+      time_format %s
+      time_field time
+
+      field_integer time
+      field_string vhost, referer
+      field_boolean bot_access, login_session
+    CONFIG
+    mock_client(driver) do |expect|
+      expect.discovered_api("bigquery", "v2") { stub! }
+    end
+    driver.instance.start
+    buf = driver.instance.format_stream("my.tag", [input])
+    driver.instance.shutdown
+
+    assert_equal expected, MessagePack.unpack(buf)
+  end
+
   def test_write
     entry = {"json" => {"a" => "b"}}, {"json" => {"b" => "c"}}
     driver = create_driver(CONFIG)

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -712,7 +712,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       dataset yourdataset_id
 
       replace_record_key true
-      replace_record_regexp1 - _
+      replace_record_key_regexp1 - _
 
       time_format %s
       time_field time

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -712,7 +712,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       dataset yourdataset_id
 
       replace_record_key true
-      regexp1 - _
+      replace_record_regexp1 - _
 
       time_format %s
       time_field time


### PR DESCRIPTION
When record' key contains except A-Z, a-z, 0-9, and the underscore, the filed of the table is null.
To support this situation, I implemented replacement function.