### PR TITLE
Support JSON key file and application default credentials authentication

### DIFF
--- a/test/plugin/testdata/json_key.json
+++ b/test/plugin/testdata/json_key.json
@@ -1,0 +1,7 @@
+{
+  "private_key_id": "1",
+  "private_key": "X",
+  "client_email": "xxx@developer.gserviceaccount.com",
+  "client_id": "xxx.apps.googleusercontent.com",
+  "type": "service_account"
+}


### PR DESCRIPTION
As you know, google recommended to use JSON key for service account.

<img width="461" alt="2015-10-19 23 32 30" src="https://cloud.githubusercontent.com/assets/346598/10580723/d292d7b0-76b9-11e5-9303-d64d91aa8538.png">

So it's a time to support JSON key.
This pull request will fix #49 

In this pull request, I add two authentication type, `json_key` and `application_default`.

## json_key

This type support JSON key file. I also added embedded key, which enable you to embedded JSON key in fluentd configuration file

### JSON key file

You can specify JSON key file by `json_key` file.

```apache
<match dummy>
  type bigquery
  auth_method json_key
  json_key /home/username/.keys/00000000000000000000000000000000-jsonkey.json
  ...
</match>
```

### Embedded JSON key

If file specified by `json_key` is not exists, plugin try to parse it as embedded JSON key.
Value must be valid JSON and must include `private_key` and `client_email` key and value from your JSON key file.

```apache
<match dummy>
  type bigquery
  auth_method json_key
  json_key {
    "private_key": "-----BEGIN PRIVATE KEY-----\n...",
    "client_email": "xxx@developer.gserviceaccount.com"
  }
</match>
```

This is very handy, because you can only deploy fluentd config file without copy key file to your server.

## application_default

The Application Default Credentials provide a simple way to get authorization credentials for use in calling Google APIs, which are described in detail at http://goo.gl/IUuyuX.

In this authentication method, the credentials returned are determined by the environment the code is running in. Conditions are checked in the following order:credentials are get from following order.

1. The environment variable `GOOGLE_APPLICATION_CREDENTIALS` is checked. If this variable is specified it should point to a JSON key file that defines the credentials.
2. The environment variable `GOOGLE_PRIVATE_KEY` and `GOOGLE_CLIENT_EMAIL` are checked. If this variables are specified `GOOGLE_PRIVATE_KEY` should point to `private_key`, `GOOGLE_CLIENT_EMAIL` should point to `client_email` in a JSON key.
3. Well known path is checked. If file is exists, the file used as a JSON key file. This path is `$HOME/.config/gcloud/application_default_credentials.json`.
4. System default path is checked. If file is exists, the file used as a JSON key file. This path is `/etc/google/auth/application_default_credentials.json`.
5. If you are running in Google Compute Engine production, the built-in service account associated with the virtual machine instance will be used.
6. If none of these conditions is true, an error will occur.

These loggics are implemented by [googleauth gem](https://github.com/google/google-auth-library-ruby/blob/master/lib/googleauth.rb#L111-L118).