### PR TITLE
Add convert feature from hash to json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
 
+before_install:
+  - gem update bundler
+
 script: bundle exec rake test

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -83,6 +83,8 @@ module Fluent
     config_param :replace_record_key, :bool, default: false
     (1..REGEXP_MAX_NUM).each {|i| config_param :"replace_record_key_regexp#{i}", :string, default: nil }
 
+    config_param :convert_hash_to_json, :bool, default: false
+
     config_param :time_format, :string, default: nil
     config_param :localtime, :bool, default: nil
     config_param :utc, :bool, default: nil
@@ -367,12 +369,25 @@ module Fluent
       new_record
     end
 
+    def convert_hash_to_json(record)
+      record.each do |key, value|
+        if value.class == Hash
+          record[key] = value.to_json
+        end
+      end
+      record
+    end
+
     def format_stream(tag, es)
       super
       buf = ''
       es.each do |time, record|
         if @replace_record_key
           record = replace_record_key(record)
+        end
+
+        if @convert_hash_to_json
+          record = convert_hash_to_json(record)
         end
 
         row = @fields.format(@add_time_field.call(record, time))


### PR DESCRIPTION
To realize schema-less in BigQuery, someone try to insert json as string.
However, inserted string is hash format.

This pull request will fix #51 

### Configuration
```
# default false
convert_hash_to_json true
```