### PR TITLE
fix Missing token endpoint URI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
 
+before_install:
+  - gem update bundler
+
 script: bundle exec rake test

--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", "~> 1.0.3"
 
   spec.add_runtime_dependency "google-api-client", "~> 0.8.0"
-  spec.add_runtime_dependency "googleauth"
+  spec.add_runtime_dependency "googleauth", ">=  0.5.0"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   spec.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -255,11 +255,11 @@ module Fluent
       when 'json_key'
         if File.exist?(@json_key)
           auth = File.open(@json_key) do |f|
-            Google::Auth::ServiceAccountCredentials.new(json_key_io: f, scope: scope)
+            Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: f, scope: scope)
           end
         else
           key = StringIO.new(@json_key)
-          auth = Google::Auth::ServiceAccountCredentials.new(json_key_io: key, scope: scope)
+          auth = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: key, scope: scope)
         end
 
       when 'application_default'

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -105,7 +105,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     json_key_path = 'test/plugin/testdata/json_key.json'
     authorization = Object.new
     mock(authorization).fetch_access_token!
-    mock(Google::Auth::ServiceAccountCredentials).new(json_key_io: File.open(json_key_path), scope: API_SCOPE) { authorization }
+    mock(Google::Auth::ServiceAccountCredentials).make_creds(json_key_io: File.open(json_key_path), scope: API_SCOPE) { authorization }
 
     mock.proxy(Google::APIClient).new.with_any_args {
       mock!.__send__(:authorization=, authorization) {}
@@ -128,7 +128,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     mock(StringIO).new(json_key) { json_key_io }
     authorization = Object.new
     mock(authorization).fetch_access_token!
-    mock(Google::Auth::ServiceAccountCredentials).new(json_key_io: json_key_io, scope: API_SCOPE) { authorization }
+    mock(Google::Auth::ServiceAccountCredentials).make_creds(json_key_io: json_key_io, scope: API_SCOPE) { authorization }
 
     mock.proxy(Google::APIClient).new.with_any_args {
       mock!.__send__(:authorization=, authorization) {}


### PR DESCRIPTION
googleauth gem has changed api since 0.5.0, using `Google::Auth::ServiceAccountCredentials.new` cause ArgumentsError when execute `fetch_access_token!`.

this PR fix above using `Google::Auth::ServiceAccountCredentials.make_creds`.

