### PR TITLE
Fix googleauth dependency because v0.5.x has different API

### DIFF
--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", "~> 1.0.3"
 
   spec.add_runtime_dependency "google-api-client", "~> 0.8.0"
-  spec.add_runtime_dependency "googleauth"
+  spec.add_runtime_dependency "googleauth", "~> 0.4.2"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   spec.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"


### PR DESCRIPTION
At the current point in time, unless version of googleauth is not fixed, rubygem installs googleauth-0.5.x.
But API of googleauth-0.5.x is different with v0.4.x.
Because of it, fluent-plugin-bigquery raises ArgumentError exception.

```
% be fluentd -c fluent.conf
2016-01-09 19:58:01 +0900 [info]: reading config file path="fluent.conf"
2016-01-09 19:58:01 +0900 [info]: starting fluentd-0.12.16
2016-01-09 19:58:01 +0900 [info]: gem 'fluentd' version '0.12.16'
2016-01-09 19:58:01 +0900 [info]: gem 'fluent-mixin-config-placeholders' version '0.3.0'
2016-01-09 19:58:01 +0900 [info]: gem 'fluent-mixin-plaintextformatter' version '0.2.6'
2016-01-09 19:58:01 +0900 [info]: gem 'fluent-plugin-buffer-lightening' version '0.0.2'
2016-01-09 19:58:01 +0900 [info]: gem 'fluent-plugin-bigquery' version '0.2.12'
2016-01-09 19:58:01 +0900 [info]: gem 'fluent-plugin-file-alternative' version '0.2.0'
2016-01-09 19:58:01 +0900 [info]: adding match pattern="**" type="bigquery"
2016-01-09 19:58:01 +0900 [info]: adding source type="forward"
2016-01-09 19:58:01 +0900 [info]: using configuration file: <ROOT>
  <source>
    type forward
  </source>
  <match **>
    type bigquery
    method insert
    auth_method json_key
    json_key /Users/joker/test_key.json
    省略
  </match>
</ROOT>
2016-01-09 19:58:01 +0900 [error]: unexpected error error_class=ArgumentError error=#<ArgumentError: Missing token endpoint URI.>
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/signet-0.7.2/lib/signet/oauth_2/client.rb:951:in `fetch_access_token'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/signet-0.7.2/lib/signet/oauth_2/client.rb:998:in `fetch_access_token!'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/googleauth-0.5.1/lib/googleauth/signet.rb:69:in `fetch_access_token!'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/.ghq/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery.rb:272:in `client'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/.ghq/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery.rb:222:in `start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/agent.rb:67:in `block in start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/agent.rb:66:in `each'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/agent.rb:66:in `start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/root_agent.rb:104:in `start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/engine.rb:211:in `start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/engine.rb:161:in `run'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:579:in `run_engine'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:147:in `block in start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:336:in `main_process'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:311:in `block in supervise'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:310:in `fork'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:310:in `supervise'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/supervisor.rb:141:in `start'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/lib/fluent/command/fluentd.rb:171:in `<top (required)>'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/bin/fluentd:6:in `require'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/gems/fluentd-0.12.16/bin/fluentd:6:in `<top (required)>'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/bin/fluentd:23:in `load'
  2016-01-09 19:58:01 +0900 [error]: /Users/joker/fluentd_workspace/.bundle/ruby/2.3.0/bin/fluentd:23:in `<main>'
2016-01-09 19:58:01 +0900 [info]: shutting down fluentd
2016-01-09 19:58:01 +0900 [info]: process finished code=0
```