### PR TITLE
Change base class from BufferedOutput to TimeSlicedOutput

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,23 @@ The format can be suffixed with attribute name.
 If attribute name is given, the time to be used for formatting is value of each row.
 The value for the time should be a UNIX time.
 
+Or, the options can use `%{time_slice}` placeholder.
+`%{time_slice}` is replaced by formatted time slice key at runtime.
+
+```apache
+<match dummy>
+  type bigquery
+  
+  ...
+  
+  project yourproject_id
+  dataset yourdataset_id
+  table   accesslog%{time_slice}
+  
+  ...
+</match>
+```
+
 ### Dynamic table creating
 
 When `auto_create_table` is set to `true`, try to create the table using BigQuery API when insertion failed with code=404 "Not Found: Table ...".


### PR DESCRIPTION
This feature is inspired by [fluent-plugin-s3](https://github.com/fluent/fluent-plugin-s3 "fluent/fluent-plugin-s3").

Time sliced table is popular use case of bigquery.
For example, accesslogs20160102.
Time sliced table can be target of table wildcard functions (`TABLE_DATE_RANGE`).
cf. https://cloud.google.com/bigquery/query-reference#tablewildcardfunctions

But current fluent-plugin-bigquery use `Fluent::Engine.now` as base time for table name format .
the time and each record timestamp is not always consistant.
Because of it, we have some troubles. We must take care of boundary of day.

Time sliced plugin makes table name and record timestamp consistant.