### PR TITLE
Allow ${attr_name} to use value of attribute as part of table id

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,25 @@ Or, the options can use `%{time_slice}` placeholder.
 </match>
 ```
 
+#### record attribute value formatting
+Or, `${attr_name}` placeholder is available to use value of attribute as part of table id.
+`${attr_name}` is replaced by string value of the attribute specified by `attr_name`.
+
+__NOTE: This feature is available only if `method` is `insert`.__
+
+```apache
+<match dummy>
+  ...
+  table   accesslog_%Y_%m_${subdomain}
+  ...
+</match>
+```
+
+For example value of `subdomain` attribute is `"bq.fluent"`, table id will be like "accesslog_2016_03_bqfluent".
+
+- any type of attribute is allowed because stringified value will be used as replacement.
+- acceptable characters are alphabets, digits and `_`. All other characters will be removed.
+
 ### Dynamic table creating
 
 When `auto_create_table` is set to `true`, try to create the table using BigQuery API when insertion failed with code=404 "Not Found: Table ...".

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -294,6 +294,12 @@ module Fluent
              else
                current_time
              end
+      if row && format =~ /\$\{/
+        json = row[:json]
+        format.gsub!(/\$\{\s*(\w+)\s*\}/) do |m|
+          row[:json][$1.to_sym].to_s.gsub(/[^\w]/, '')
+        end
+      end
       table_id = time.strftime(format)
 
       if chunk


### PR DESCRIPTION
This feature is to set destination table dynamically based on value of attribute.
It introduces `${attr_name}` placeholder to use value of attribute as part of table id.

`${attr_name}` is replaced by string value of the attribute specified by `attr_name`.

```apache
<match dummy>
  ...
  table   accesslog_%Y_%m_${subdomain}
  ...
</match>
```

For example value of `subdomain` attribute is `"bq.fluent"`, table id will be like "accesslog_2016_03_bqfluent".

- any type of attribute is allowed because stringified value will be used as replacement.
- acceptable characters are alphabets, digits and `_`. All other characters will be removed.