### PR TITLE
Fix record formatting

### DIFF
--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -275,9 +275,15 @@ class BigQueryOutputTest < Test::Unit::TestCase
         "requesttime" => (now - 1).to_f.to_s.to_f,
         "bot_access" => true,
         "loginsession" => false,
+        "something-else" => "would be ignored",
+        "yet-another" => {
+          "foo" => "bar",
+          "baz" => 1,
+        },
         "remote" => {
           "host" => "remote.example",
           "ip" =>  "192.0.2.1",
+          "port" => 12345,
           "user" => "tagomoris",
         }
       }
@@ -429,11 +435,17 @@ class BigQueryOutputTest < Test::Unit::TestCase
         "remote" => {
           "host" => "remote.example",
           "ip" =>  "192.0.2.1",
+          "port" => 12345,
           "user" => "tagomoris",
         },
         "response" => {
           "status" => 1,
           "bytes" => 3,
+        },
+        "something-else" => "would be ignored",
+        "yet-another" => {
+          "foo" => "bar",
+          "baz" => 1,
         },
       }
     }
@@ -737,38 +749,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
     driver.instance.shutdown
 
     assert_equal expected, buf
-  end
-
-  def test_empty_value_in_required
-    now = Time.now
-    input = [
-      now,
-      {
-        "tty" => "pts/1",
-        "pwd" => "/home/yugui",
-        "user" => nil,
-        "argv" => %w[ tail -f /var/log/fluentd/fluentd.log ]
-      }
-    ]
-
-    driver = create_driver(<<-CONFIG)
-      table foo
-      email foo@bar.example
-      private_key_path /path/to/key
-      project yourproject_id
-      dataset yourdataset_id
-
-      time_format %s
-      time_field  time
-
-      schema_path #{File.join(File.dirname(__FILE__), "testdata", "sudo.schema")}
-      field_integer time
-    CONFIG
-    driver.instance.start
-    assert_raises(RuntimeError.new("Required field user cannot be null")) do
-      driver.instance.format_stream("my.tag", [input])
-    end
-    driver.instance.shutdown
   end
 
   def test_replace_record_key

--- a/test/plugin/test_record_schema.rb
+++ b/test/plugin/test_record_schema.rb
@@ -1,0 +1,139 @@
+require 'helper'
+require 'active_support/json'
+require 'active_support/core_ext/hash'
+require 'active_support/core_ext/object/json'
+
+class RecordSchemaTest < Test::Unit::TestCase
+  def base_schema
+    [
+      {
+        "name" => "time",
+        "type" => "TIMESTAMP",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "tty",
+        "type" => "STRING",
+        "mode" => "NULLABLE"
+      },
+      {
+        "name" => "pwd",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "user",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "argv",
+        "type" => "STRING",
+        "mode" => "REPEATED"
+      }
+    ]
+  end
+
+  def base_schema_with_new_column
+    [
+      {
+        "name" => "time",
+        "type" => "TIMESTAMP",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "tty",
+        "type" => "STRING",
+        "mode" => "NULLABLE"
+      },
+      {
+        "name" => "pwd",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "user",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "argv",
+        "type" => "STRING",
+        "mode" => "REPEATED"
+      },
+      {
+        "name" => "new_column",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      }
+    ]
+  end
+
+  def base_schema_with_type_changed_column
+    [
+      {
+        "name" => "time",
+        "type" => "INTEGER", # change type
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "tty",
+        "type" => "STRING",
+        "mode" => "NULLABLE"
+      },
+      {
+        "name" => "pwd",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "user",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
+      },
+      {
+        "name" => "argv",
+        "type" => "STRING",
+        "mode" => "REPEATED"
+      },
+    ]
+  end
+
+  def test_load_schema
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, true)
+    assert { fields.to_a.as_json == base_schema }
+  end
+
+  def test_load_schema_allow_overwrite_with_type_changed_column
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, true)
+
+    fields.load_schema(base_schema_with_type_changed_column, true)
+    assert { fields.to_a.as_json == base_schema_with_type_changed_column }
+  end
+
+  def test_load_schema_allow_overwrite_with_new_column
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, true)
+
+    fields.load_schema(base_schema_with_new_column, true)
+    assert { fields.to_a.as_json == base_schema_with_new_column }
+  end
+
+  def test_load_schema_not_allow_overwrite_with_type_changed_column
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, false)
+
+    fields.load_schema(base_schema_with_type_changed_column, false)
+    assert { fields.to_a.as_json == base_schema }
+  end
+
+  def test_load_schema_no_allow_overwrite_with_new_column
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, false)
+
+    fields.load_schema(base_schema_with_new_column, false)
+    assert { fields.to_a.as_json == base_schema_with_new_column }
+  end
+end

--- a/test/plugin/test_record_schema.rb
+++ b/test/plugin/test_record_schema.rb
@@ -136,4 +136,38 @@ class RecordSchemaTest < Test::Unit::TestCase
     fields.load_schema(base_schema_with_new_column, false)
     assert { fields.to_a.as_json == base_schema_with_new_column }
   end
+
+  def test_format_one
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, false)
+
+    time = Time.local(2016, 2, 7, 19, 0, 0).utc
+
+    formatted = fields.format_one({
+      "time" => time, "tty" => nil, "pwd" => "/home", "user" => "joker1007", "argv" => ["foo", 42]
+    })
+    assert_equal(
+      formatted,
+      {
+        "time" => time.strftime("%Y-%m-%d %H:%M:%S.%6L %:z"), "pwd" => "/home", "user" => "joker1007", "argv" => ["foo", "42"]
+      }
+    )
+  end
+
+  def test_format_one_with_extra_column
+    fields = Fluent::BigQueryOutput::RecordSchema.new("record")
+    fields.load_schema(base_schema, false)
+
+    time = Time.local(2016, 2, 7, 19, 0, 0).utc
+
+    formatted = fields.format_one({
+      "time" => time, "tty" => nil, "pwd" => "/home", "user" => "joker1007", "argv" => ["foo", 42.195], "extra" => "extra_data"
+    })
+    assert_equal(
+      formatted,
+      {
+        "time" => time.strftime("%Y-%m-%d %H:%M:%S.%6L %:z"), "pwd" => "/home", "user" => "joker1007", "argv" => ["foo", "42.195"], "extra" => "extra_data"
+      }
+    )
+  end
 end


### PR DESCRIPTION
- format `Time` or `String` value for bigquery timestamp column
- even if required field value is empty, not raise exception.
  - because current version cannot use secondary output.
- not filter out extra column.
  - use ignore_unknown_values instead of it.