### PR TITLE
Add prevent_duplicate_load option

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -106,7 +106,10 @@ module Fluent
     config_param :utc, :bool, default: nil
     config_param :time_field, :string, default: nil
 
+    # insert_id_field (only insert)
     config_param :insert_id_field, :string, default: nil
+    # prevent_duplicate_load (only load)
+    config_param :prevent_duplicate_load, :bool, default: false
 
     config_param :method, :string, default: 'insert' # or 'load'
 
@@ -523,8 +526,9 @@ module Fluent
 
       def load(chunk, table_id, template_suffix)
         res = nil
+        job_id = nil
         create_upload_source(chunk) do |upload_source|
-          configuration = load_configuration(table_id, template_suffix)
+          configuration, job_id = load_configuration(table_id, template_suffix, upload_source)
           res = client.insert_job(
             @project,
             configuration,
@@ -545,7 +549,10 @@ module Fluent
 
         reason = e.respond_to?(:reason) ? e.reason : nil
         log.error "job.load API", project_id: @project, dataset: @dataset, table: table_id, code: e.status_code, message: e.message, reason: reason
-        if RETRYABLE_ERROR_REASON.include?(reason)
+
+        return wait_load(job_id) if job_id && e.status_code == 409 && e.message =~ /Job/ # duplicate load job
+
+        if RETRYABLE_ERROR_REASON.include?(reason) || e.is_a?(Google::Apis::ServerError)
           raise "failed to insert into bigquery, retry" # TODO: error class
         elsif @secondary
           flush_secondary(@secondary)
@@ -554,7 +561,12 @@ module Fluent
 
       private
 
-      def load_configuration(table_id, template_suffix)
+      def load_configuration(table_id, template_suffix, upload_source)
+        job_id = nil
+        if @prevent_duplicate_load
+          job_id = create_job_id(upload_source, @dataset, "#{table_id}#{template_suffix}", @fields.to_a, @max_bad_records, @ignore_unknown_values)
+        end
+
         configuration = {
           configuration: {
             load: {
@@ -573,6 +585,7 @@ module Fluent
             }
           }
         }
+        configuration.merge!({job_reference: {project_id: @project, job_id: job_id}}) if job_id
 
         # If target table is already exist, omit schema configuration.
         # Because schema changing is easier.
@@ -584,7 +597,7 @@ module Fluent
           raise "Schema is empty" if @fields.empty?
         end
 
-        configuration
+        return configuration, job_id
       end
 
       def wait_load(res, table_id)
@@ -606,7 +619,7 @@ module Fluent
         error_result = _response.status.error_result
         if error_result
           log.error "job.load API (result)", project_id: @project, dataset: @dataset, table: table_id, message: error_result.message, reason: error_result.reason
-          if RETRYABLE_ERROR_REASON.include?(_response.status.error_result.reason)
+          if RETRYABLE_ERROR_REASON.include?(error_result.reason)
             raise "failed to load into bigquery"
           elsif @secondary
             flush_secondary(@secondary)
@@ -631,6 +644,17 @@ module Fluent
             yield file
           end
         end
+      end
+
+      def create_job_id(upload_source, dataset, table, schema, max_bad_records, ignore_unknown_values)
+        # OPTIMIZE: for memory buffer,  but it is inefficient
+        if upload_source.respond_to?(:path)
+          base_digest = Digest::SHA1.hexdigest(upload_source.path)
+        else
+          base_digest = Digest::SHA1.hexdigest(upload_source.read)
+          upload_source.rewind
+        end
+        "fluentd_job_" + Digest::SHA1.hexdigest("#{base_digest}#{dataset}#{table}#{schema.to_s}#{max_bad_records}#{ignore_unknown_values}")
       end
     end
 

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -1075,7 +1075,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
             max_bad_records: 0,
           },
         },
-        job_reference: {project_id: 'yourproject_id', job_id: "fluentd_job_150bce35c54f3dd0de9252b4917ef542d221c53a"},
+        job_reference: {project_id: 'yourproject_id', job_id: satisfy { |x| x =~ /fluentd_job_.*/}} ,
       }, {upload_source: io, content_type: "application/octet-stream", options: {timeout_sec: nil, open_timeout_sec: 60}}) {
         s = stub!
         status_stub = stub!

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -993,6 +993,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     chunk = Fluent::MemoryBufferChunk.new("my.tag")
     io = StringIO.new("hello")
     mock(driver.instance).create_upload_source(chunk).yields(io)
+    mock(driver.instance).wait_load("dummy_job_id", "foo") { true }
     mock_client(driver) do |expect|
       expect.insert_job('yourproject_id', {
         configuration: {
@@ -1013,11 +1014,9 @@ class BigQueryOutputTest < Test::Unit::TestCase
         }
       }, {upload_source: io, content_type: "application/octet-stream", options: {timeout_sec: nil, open_timeout_sec: 60}}) {
         s = stub!
-        status_stub = stub!
-        s.status { status_stub }
-        status_stub.state { "DONE" }
-        status_stub.error_result { nil }
-        status_stub.errors { nil }
+        job_reference_stub = stub!
+        s.job_reference { job_reference_stub }
+        job_reference_stub.job_id { "dummy_job_id" }
         s
       }
     end
@@ -1057,6 +1056,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
     chunk = Fluent::MemoryBufferChunk.new("my.tag")
     io = StringIO.new("hello")
     mock(driver.instance).create_upload_source(chunk).yields(io)
+    mock(driver.instance).wait_load("dummy_job_id", "foo") { true }
     mock_client(driver) do |expect|
       expect.insert_job('yourproject_id', {
         configuration: {
@@ -1078,11 +1078,9 @@ class BigQueryOutputTest < Test::Unit::TestCase
         job_reference: {project_id: 'yourproject_id', job_id: satisfy { |x| x =~ /fluentd_job_.*/}} ,
       }, {upload_source: io, content_type: "application/octet-stream", options: {timeout_sec: nil, open_timeout_sec: 60}}) {
         s = stub!
-        status_stub = stub!
-        s.status { status_stub }
-        status_stub.state { "DONE" }
-        status_stub.error_result { nil }
-        status_stub.errors { nil }
+        job_reference_stub = stub!
+        s.job_reference { job_reference_stub }
+        job_reference_stub.job_id { "dummy_job_id" }
         s
       }
     end
@@ -1140,6 +1138,14 @@ class BigQueryOutputTest < Test::Unit::TestCase
           }
         }
       }, {upload_source: io, content_type: "application/octet-stream", options: {timeout_sec: nil, open_timeout_sec: 60}}) {
+        s = stub!
+        job_reference_stub = stub!
+        s.job_reference { job_reference_stub }
+        job_reference_stub.job_id { "dummy_job_id" }
+        s
+      }
+
+      expect.get_job('yourproject_id', 'dummy_job_id') {
         s = stub!
         status_stub = stub!
         error_result = stub!
@@ -1214,6 +1220,14 @@ class BigQueryOutputTest < Test::Unit::TestCase
           }
         }
       }, {upload_source: io, content_type: "application/octet-stream", options: {timeout_sec: nil, open_timeout_sec: 60}}) {
+        s = stub!
+        job_reference_stub = stub!
+        s.job_reference { job_reference_stub }
+        job_reference_stub.job_id { "dummy_job_id" }
+        s
+      }
+
+      expect.get_job('yourproject_id', 'dummy_job_id') {
         s = stub!
         status_stub = stub!
         error_result = stub!


### PR DESCRIPTION
In order to avoid to load duplicate records when Bigquery Server error is occured
it uses job_id generation by SHA1.

SHA1 body is `"#{base_digest}#{dataset}#{table}#{schema.to_s}#{max_bad_records}#{ignore_unknown_values}"`

If buffer type is file, `base_digest` is SHA1 of buffer file path.
If buffer type is memory, `base_digest` is SHA1 of buffer body. (it is inefficient, but i don't have other idea)