### PR TITLE
Add logging for insert errors

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -120,10 +120,11 @@ module Fluent
           ignore_unknown_values: ignore_unknown_values,
         }
         body.merge!(template_suffix: template_suffix) if template_suffix
-        client.insert_all_table_data(project, dataset, table_id, body, {
+        res = client.insert_all_table_data(project, dataset, table_id, body, {
           options: {timeout_sec: timeout_sec, open_timeout_sec: open_timeout_sec}
         })
         log.debug "insert rows", project_id: project, dataset: dataset, table: table_id, count: rows.size
+        log.warn "insert errors", insert_errors: res.insert_errors if res.insert_errors && !res.insert_errors.empty?
       rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e
         @client = nil
 


### PR DESCRIPTION
I added logging by warn when streaming insert had problems.

I have faced insert errors when using streaming insert.
But, client don't raise exception, because HTTP request has succeeded.
So, I want to know some wrong of insertion data, e.g. bigquery can't parse timestamp.

see: http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/BigqueryV2/InsertAllTableDataResponse#insert_errors-instance_method