### PR TITLE
Strict dependency for old ruby versions

### DIFF
--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "google-api-client", "~> 0.9.3"
   spec.add_runtime_dependency "googleauth", ">= 0.5.0"
   spec.add_runtime_dependency "multi_json"
-  spec.add_runtime_dependency "activesupport", ">= 3.2"
+  spec.add_runtime_dependency "activesupport", ">= 3.2", "< 5.0"
   spec.add_runtime_dependency "fluentd", "~> 0.12.0"
   spec.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   spec.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"


### PR DESCRIPTION
active support v5 don't support old rubies, so I added constraint to dependency to support old rubies.