### PR TITLE
Fix nil handling of REPEATED column

### DIFF
--- a/lib/fluent/plugin/bigquery/schema.rb
+++ b/lib/fluent/plugin/bigquery/schema.rb
@@ -33,7 +33,7 @@ module Fluent
             format_one(value)
           end
         when :repeated
-          value.nil? ? [] : value.map {|v| format_one(v) }
+          value.nil? ? [] : value.each_with_object([]) { |v, arr| arr << format_one(v) if v }
         end
       end
 


### PR DESCRIPTION
If payload has array that includes nil value, plugin passes nil to `format_one` method.
because of it, NoMethodError is occured.