### PR TITLE
Make json_key param secret

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -54,7 +54,7 @@ module Fluent
     config_param :email, :string, default: nil
     config_param :private_key_path, :string, default: nil
     config_param :private_key_passphrase, :string, default: 'notasecret', secret: true
-    config_param :json_key, default: nil
+    config_param :json_key, default: nil, secret: true
 
     # see as simple reference
     #   https://github.com/abronte/BigQuery/blob/master/lib/bigquery.rb


### PR DESCRIPTION
When auth_method is json_key and json_key is set as a JSON string, it includes a private key which should be masked.
So I add `secret: true` option to json_key config param.

How do you think it?