### PR TITLE
Give up retry immediately, If prevent_duplicate_load is true and result of load job is error.

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -187,7 +187,7 @@ module Fluent
         reason = e.respond_to?(:reason) ? e.reason : nil
         log.error "job.load API", project_id: project, dataset: dataset, table: table_id, code: e.status_code, message: e.message, reason: reason
 
-        return wait_load_job(project, dataset, job_id, table_id) if job_id && e.status_code == 409 && e.message =~ /Job/ # duplicate load job
+        return wait_load_job(project, dataset, job_id, table_id, retryable: false) if job_id && e.status_code == 409 && e.message =~ /Job/ # duplicate load job
 
         if RETRYABLE_ERROR_REASON.include?(reason) || e.is_a?(Google::Apis::ServerError)
           raise RetryableError.new(nil, e)
@@ -196,7 +196,7 @@ module Fluent
         end
       end
 
-      def wait_load_job(project, dataset, job_id, table_id)
+      def wait_load_job(project, dataset, job_id, table_id, retryable: true)
         wait_interval = 10
         _response = client.get_job(project, job_id)
 
@@ -216,7 +216,7 @@ module Fluent
         error_result = _response.status.error_result
         if error_result
           log.error "job.insert API (result)", job_id: job_id, project_id: project, dataset: dataset, table: table_id, message: error_result.message, reason: error_result.reason
-          if RETRYABLE_ERROR_REASON.include?(error_result.reason)
+          if retryable && RETRYABLE_ERROR_REASON.include?(error_result.reason)
             raise RetryableError.new("failed to load into bigquery, retry")
           else
             raise UnRetryableError.new("failed to load into bigquery, and cannot retry")


### PR DESCRIPTION
Because current spec of job_id calculation cannot cover this case.