### PR TITLE
Update configuration parameters

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -235,13 +235,13 @@ module Fluent
 
       def get_auth
         case @auth_method
-        when 'private_key'
+        when :private_key
           get_auth_from_private_key
-        when 'compute_engine'
+        when :compute_engine
           get_auth_from_compute_engine
-        when 'json_key'
+        when :json_key
           get_auth_from_json_key
-        when 'application_default'
+        when :application_default
           get_auth_from_application_default
         else
           raise ConfigError, "Unknown auth method: #{@auth_method}"


### PR DESCRIPTION
* Fix not to add accessor for "method": it hides Object#method (and it breaks Fluentd v0.14 behavior)
* Fix to use :enum instead of checking values by itself

This change is the first step to make this plugin to work with Fluentd v0.14.

I modified dependency for Fluentd to `~> 0.12.10`. It was released at May 2015, so I believe that users aren't using such version now, or can update their Fluentd to newer 0.12.x versions.