### PR TITLE
Fix json_key file opening to raise Errno::EACCES properly

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -271,11 +271,11 @@ module Fluent
       def get_auth_from_json_key
         json_key = @auth_options[:json_key]
 
-        if File.exist?(json_key)
+        begin
           File.open(json_key) do |f|
             Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: f, scope: @scope)
           end
-        else
+        rescue Errno::ENOENT
           key = StringIO.new(json_key)
           Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: key, scope: @scope)
         end


### PR DESCRIPTION
## Problem

When `json_key` file is stored in a directory which fluentd cannot read, it raisese `MultiJson::ParseError` from [here](https://github.com/kaizenplatform/fluent-plugin-bigquery/blob/6cfd022dad86a509bd4ef9a4a7c81563fb15d476/lib/fluent/plugin/bigquery/writer.rb#L280).

```
2016-09-24 22:09:28 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2016-09-24 22:09:30 +0900 error_class="MultiJson::ParseError" error="unexpected character at line 1, column 2 [parse.c:666]" plugin_id="object:3fd33a734518"
```

It's less informative.

## Solution

Open `json_key` file without checking `File.exist?` and let it raise error.
If the error is `Errno::ENOENT`, it rescues the error and treats the `json_key` value as JSON data.
Otherwise it raises the error.

```
2016-09-24 22:09:15 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2016-09-24 22:10:26 +0900 error_class="Errno::EACCES" error="Permission denied @ rb_sysopen - /etc/td-agent/bigquery/key.json" plugin_id="object:3fb3ce934a9c"
```