### PR TITLE
Refactor template suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ OAuth flow for installed applications.
 | ignore_unknown_values                  | bool          | no                          | false                                                  | Accept rows that contain values that do not match the schema. The unknown values are ignored.                        |
 | schema_path                            | string        | yes (either `fetch_schema`) | nil                                                    | Schema Definition file path. It is formatted by JSON.                                                                |
 | fetch_schema                           | bool          | yes (either `schema_path`)  | false                                                  | If true, fetch table schema definition from Bigquery table automatically.                                            |
+| fetch_schema_table                     | string        | no                          | nil                                                    | If set, fetch table schema definition from this table, If fetch_schema is false, this param is ignored               |
 | schema_cache_expire                    | integer       | no                          | 600                                                    | Value is second. If current time is after expiration interval, re-fetch table schema definition.                     |
 | field_string                           | string        | no                          | nil                                                    | see examples.                                                                                                        |
 | field_integer                          | string        | no                          | nil                                                    | see examples.                                                                                                        |
@@ -355,6 +356,24 @@ For example value of `subdomain` attribute is `"bq.fluent"`, table id will be li
 - any type of attribute is allowed because stringified value will be used as replacement.
 - acceptable characters are alphabets, digits and `_`. All other characters will be removed.
 
+### Date partitioned table support
+this plugin can insert (load) into date partitioned table.
+
+Use `%{time_slice}`.
+
+```apache
+<match dummy>
+  @type bigquery
+
+  ...
+  time_slice_format %Y%m%d
+  table   accesslog$%{time_slice}
+  ...
+</match>
+```
+
+But, Dynamic table creating doesn't support date partitioned table yet.
+
 ### Dynamic table creating
 
 When `auto_create_table` is set to `true`, try to create the table using BigQuery API when insertion failed with code=404 "Not Found: Table ...".
@@ -452,6 +471,7 @@ The third method is to set `fetch_schema` to `true` to enable fetch a schema usi
   time_field  time
   
   fetch_schema true
+  # fetch_schema_table other_table # if you want to fetch schema from other table
   field_integer time
 </match>
 ```

--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -138,14 +138,14 @@ module Fluent
         end
       end
 
-      def create_load_job(project, dataset, table_id, upload_source, job_id, fields, ignore_unknown_values: false, max_bad_records: 0, template_suffix: nil, timeout_sec: nil, open_timeout_sec: 60)
+      def create_load_job(project, dataset, table_id, upload_source, job_id, fields, ignore_unknown_values: false, max_bad_records: 0, timeout_sec: nil, open_timeout_sec: 60)
         configuration = {
           configuration: {
             load: {
               destination_table: {
                 project_id: project,
                 dataset_id: dataset,
-                table_id: "#{table_id}#{template_suffix}",
+                table_id: table_id,
               },
               schema: {
                 fields: fields.to_a,
@@ -162,7 +162,7 @@ module Fluent
         # If target table is already exist, omit schema configuration.
         # Because schema changing is easier.
         begin
-          if template_suffix && client.get_table(project, dataset, "#{table_id}#{template_suffix}")
+          if client.get_table(project, dataset, table_id)
             configuration[:configuration][:load].delete(:schema)
           end
         rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError


### PR DESCRIPTION
- `template_suffix` param is available only when `insert` mode.
- Add `fetch_schema_table` param in order to do like `template_suffix` when `load` mode.
- Update README (Date partitioned table support)