### PR TITLE
Support v0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.1
 
 before_install:
   - gem update bundler

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ OAuth flow for installed applications.
 | :------------------------------------- | :------------ | :----------- | :-------------------------     | :-----------------------           |
 | @type                                  | string        | no           | memory (insert) or file (load) |                                    |
 | chunk_limit_size                       | integer       | no           | 1MB (insert) or 1GB (load)     |                                    |
-| queue_length_limit                     | integer       | no           | 1024 (insert) or 32 (load)     |                                    |
+| total_limit_size                       | integer       | no           | 1GB (insert) or 32GB (load)    |                                    |
 | chunk_records_limit                    | integer       | no           | 500 (insert) or nil (load)     |                                    |
 | flush_mode                             | enum          | no           | interval                       | default, lazy, interval, immediate |
 | flush_interval                         | float         | no           | 0.25 (insert) or nil (load)    |                                    |

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ OAuth flow for installed applications.
 | field_float                            | string        | no                          | nil                                                    | see examples.                                                                                                        |
 | field_boolean                          | string        | no                          | nil                                                    | see examples.                                                                                                        |
 | field_timestamp                        | string        | no                          | nil                                                    | see examples.                                                                                                        |
-| time_field                             | string        | no                          | nil                                                    | If this param is set, plugin set formatted time string to this field.                                                |
-| time_format                            | string        | no                          | nil                                                    | ex. `%s`, `%Y/%m%d %H:%M:%S`                                                                                         |
 | replace_record_key                     | bool          | no                          | false                                                  | see examples.                                                                                                        |
 | replace_record_key_regexp{1-10}        | string        | no                          | nil                                                    | see examples.                                                                                                        |
 | convert_hash_to_json                   | bool          | no                          | false                                                  | If true, converts Hash value of record to JSON String.                                                               |
@@ -71,6 +69,34 @@ And, other params (defined by base class) are available
 
 see. https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/output.rb
 
+### Inject section
+
+It is replacement of previous version `time_field` and `time_format`.
+
+For example.
+
+```
+<inject>
+  time_key time_field_name
+  time_type string
+  time_format %Y-%m-%d %H:%M:%S
+</inject>
+```
+
+| name                                   | type          | required?    | default                    | description              |
+| :------------------------------------- | :------------ | :----------- | :------------------------- | :----------------------- |
+| hostname_key                           | string        | no           | nil                        |                          |
+| hostname                               | string        | no           | nil                        |                          |
+| tag_key                                | string        | no           | nil                        |                          |
+| time_key                               | string        | no           | nil                        |                          |
+| time_type                              | string        | no           | nil                        |                          |
+| time_format                            | string        | no           | nil                        |                          |
+| localtime                              | bool          | no           | true                       |                          |
+| utc                                    | bool          | no           | false                      |                          |
+| timezone                               | string        | no           | nil                        |                          |
+
+see. https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin_helper/inject.rb
+
 ## Examples
 
 ### Streaming inserts
@@ -91,10 +117,7 @@ Configure insert specifications with target table schema, with your credentials.
   project yourproject_id
   dataset yourdataset_id
   table   tablename
-
-  time_format %s
-  time_field  time
-
+  
   field_integer time,status,bytes
   field_string  rhost,vhost,path,method,protocol,agent,referer
   field_float   requesttime
@@ -126,10 +149,7 @@ For high rate inserts over streaming inserts, you should specify flush intervals
   project yourproject_id
   dataset yourdataset_id
   tables  accesslog1,accesslog2,accesslog3
-
-  time_format %s
-  time_field  time
-
+  
   field_integer time,status,bytes
   field_string  rhost,vhost,path,method,protocol,agent,referer
   field_float   requesttime
@@ -183,9 +203,6 @@ section in the Google BigQuery document.
 
   auth_method json_key
   json_key json_key_path.json
-
-  time_format %s
-  time_field  time
 
   project yourproject_id
   dataset yourdataset_id
@@ -263,10 +280,7 @@ Compute Engine instance, then you can configure fluentd like this.
   project yourproject_id
   dataset yourdataset_id
   table   tablename
-
-  time_format %s
-  time_field  time
-
+  
   field_integer time,status,bytes
   field_string  rhost,vhost,path,method,protocol,agent,referer
   field_float   requesttime
@@ -402,10 +416,7 @@ you can also specify nested fields by prefixing their belonging record fields.
   @type bigquery
 
   ...
-
-  time_format %s
-  time_field  time
-
+  
   field_integer time,response.status,response.bytes
   field_string  request.vhost,request.path,request.method,request.protocol,request.agent,request.referer,remote.host,remote.ip,remote.user
   field_float   request.time
@@ -441,10 +452,7 @@ The second method is to specify a path to a BigQuery schema file instead of list
   @type bigquery
 
   ...
-
-  time_format %s
-  time_field  time
-
+  
   schema_path /path/to/httpd.schema
   field_integer time
 </match>
@@ -458,10 +466,7 @@ The third method is to set `fetch_schema` to `true` to enable fetch a schema usi
   @type bigquery
 
   ...
-
-  time_format %s
-  time_field  time
-
+  
   fetch_schema true
   # fetch_schema_table other_table # if you want to fetch schema from other table
   field_integer time

--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "googleauth", ">= 0.5.0"
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "activesupport", ">= 3.2", "< 5"
-  spec.add_runtime_dependency "fluentd", "~> 0.12.0"
+  spec.add_runtime_dependency "fluentd", "~> 0.14.0"
   spec.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   spec.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
-  spec.add_runtime_dependency "fluent-plugin-buffer-lightening", ">= 0.0.2"
 end

--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -28,6 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "activesupport", ">= 3.2", "< 5"
   spec.add_runtime_dependency "fluentd", "~> 0.14.0"
-  spec.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
-  spec.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
 end

--- a/lib/fluent/plugin/bigquery/version.rb
+++ b/lib/fluent/plugin/bigquery/version.rb
@@ -1,5 +1,5 @@
 module Fluent
   module BigQueryPlugin
-    VERSION = "0.3.3".freeze
+    VERSION = "0.4.0.beta".freeze
   end
 end

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -246,7 +246,7 @@ module Fluent
       def start
         super
 
-        @tables_queue = @tablelist.dup.shuffle
+        @tables_queue = @tablelist.shuffle
         @tables_mutex = Mutex.new
         @fetch_schema_mutex = Mutex.new
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -6,9 +6,6 @@ require 'fluent/plugin/bigquery/errors'
 require 'fluent/plugin/bigquery/schema'
 require 'fluent/plugin/bigquery/writer'
 
-## TODO: load implementation
-# require 'fluent/plugin/bigquery/load_request_body_wrapper'
-
 module Fluent
   module Plugin
     class BigQueryOutput < Output
@@ -379,7 +376,7 @@ module Fluent
             end
           end
 
-          group = rows.group_by do |row|
+          group = rows.group_by do |_|
             [
               extract_placeholders(table_format, chunk.metadata),
               template_suffix_format ? extract_placeholders(template_suffix_format, chunk.metadata) : nil,
@@ -399,9 +396,9 @@ module Fluent
             raise "table created. send rows next time."
           end
 
-          if e.retryable?
-            raise e
-          elsif @secondary
+          raise if e.retryable?
+
+          if @secondary
             # TODO: find better way
             @retry = retry_state_create(
               :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
@@ -410,7 +407,6 @@ module Fluent
               secondary: true, secondary_threshold: Float::EPSILON,
               randomize: @buffer_config.retry_randomize
             )
-            raise e
           else
             @retry = retry_state_create(
               :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
@@ -418,8 +414,9 @@ module Fluent
               max_interval: @buffer_config.retry_max_interval,
               randomize: @buffer_config.retry_randomize
             )
-            raise e
           end
+
+          raise
         end
       end
 
@@ -441,14 +438,14 @@ module Fluent
           create_upload_source(chunk) do |upload_source|
             res = writer.create_load_job(@project, @dataset, table_id, upload_source, job_id, @fields, {
               ignore_unknown_values: @ignore_unknown_values, max_bad_records: @max_bad_records,
-              timeout_sec: @request_timeout_sec,  open_timeout_sec: @request_open_timeout_sec, auto_create_table: @auto_create_table,
+              timeout_sec: @request_timeout_sec, open_timeout_sec: @request_open_timeout_sec, auto_create_table: @auto_create_table,
               time_partitioning_type: @time_partitioning_type, time_partitioning_expiration: @time_partitioning_expiration
             })
           end
         rescue Fluent::BigQuery::Error => e
-          if e.retryable?
-            raise e
-          elsif @secondary
+          raise if e.retryable?
+
+          if @secondary
             # TODO: find better way
             @retry = retry_state_create(
               :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
@@ -457,7 +454,6 @@ module Fluent
               secondary: true, secondary_threshold: Float::EPSILON,
               randomize: @buffer_config.retry_randomize
             )
-            raise e
           else
             @retry = retry_state_create(
               :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
@@ -465,8 +461,9 @@ module Fluent
               max_interval: @buffer_config.retry_max_interval,
               randomize: @buffer_config.retry_randomize
             )
-            raise e
           end
+
+          raise
         end
 
         private
@@ -489,7 +486,7 @@ module Fluent
         end
 
         def create_job_id(chunk, dataset, table, schema, max_bad_records, ignore_unknown_values)
-          "fluentd_job_" + Digest::SHA1.hexdigest("#{chunk.unique_id}#{dataset}#{table}#{schema.to_s}#{max_bad_records}#{ignore_unknown_values}")
+          "fluentd_job_" + Digest::SHA1.hexdigest("#{chunk.unique_id}#{dataset}#{table}#{schema}#{max_bad_records}#{ignore_unknown_values}")
         end
       end
     end

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -215,12 +215,12 @@ module Fluent
           @fields.load_schema(MultiJson.load(File.read(@schema_path)))
         end
 
-        types = %w(string integer float boolean timestamp)
+        types = %i(string integer float boolean timestamp)
         types.each do |type|
           fields = instance_variable_get("@field_#{type}")
           next unless fields
           fields.each do |field|
-            @fields.register_field field.strip, type.to_sym
+            @fields.register_field field.strip, type
           end
         end
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -116,8 +116,6 @@ module Fluent
       config_param :convert_hash_to_json, :bool, default: false
 
       config_param :time_format, :string, default: nil
-      config_param :localtime, :bool, default: nil
-      config_param :utc, :bool, default: nil
       config_param :time_field, :string, default: nil
 
       # insert_id_field (only insert)
@@ -243,9 +241,7 @@ module Fluent
           @regexps[regexp] = replacement
         end
 
-        @localtime = false if @localtime.nil? && @utc
-
-        @timef = TimeFormatter.new(@time_format, @localtime)
+        @timef = TimeFormatter.new(@time_format, !@buffer_config.timekey_use_utc, @buffer_config.timekey_zone)
 
         if @time_field
           keys = @time_field.split('.')

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -330,6 +330,12 @@ module Fluent
         _write(chunk, table_id_format, template_suffix_format)
       end
 
+      # for delayed commit
+      def try_write(chunk)
+        write(chunk)
+        commit_write(chunk.unique_id, delayed: true)
+      end
+
       def fetch_schema(allow_overwrite = true)
         table_id = nil
         @fetch_schema_mutex.synchronize do

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -2,9 +2,6 @@
 
 require 'fluent/plugin/bigquery/version'
 
-require 'fluent/mixin/config_placeholders'
-require 'fluent/mixin/plaintextformatter'
-
 require 'fluent/plugin/bigquery/errors'
 require 'fluent/plugin/bigquery/schema'
 require 'fluent/plugin/bigquery/writer'

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -220,7 +220,7 @@ module Fluent
           fields = instance_variable_get("@field_#{type}")
           next unless fields
           fields.each do |field|
-            @fields.register_field field.strip, type
+            @fields.register_field field, type
           end
         end
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -69,7 +69,7 @@ module Fluent
       # table_id
       #   In Table ID, enter a name for your new table. Naming rules are the same as for your dataset.
       config_param :table, :string, default: nil
-      config_param :tables, :string, default: nil # TODO: use :array with value_type: :string
+      config_param :tables, :array, value_type: :string, default: nil
 
       # template_suffix (only insert)
       #   https://cloud.google.com/bigquery/streaming-data-into-bigquery#template_table_details
@@ -95,11 +95,11 @@ module Fluent
       config_param :fetch_schema, :bool, default: false
       config_param :fetch_schema_table, :string, default: nil
       config_param :schema_cache_expire, :time, default: 600
-      config_param :field_string,  :string, default: nil
-      config_param :field_integer, :string, default: nil
-      config_param :field_float,   :string, default: nil
-      config_param :field_boolean, :string, default: nil
-      config_param :field_timestamp, :string, default: nil
+      config_param :field_string,    :array, value_type: :string, default: nil
+      config_param :field_integer,   :array, value_type: :string, default: nil
+      config_param :field_float,     :array, value_type: :string, default: nil
+      config_param :field_boolean,   :array, value_type: :string, default: nil
+      config_param :field_timestamp, :array, value_type: :string, default: nil
       ### TODO: record field stream inserts doesn't works well?
       ###  At table creation, table type json + field type record -> field type validation fails
       ###  At streaming inserts, schema cannot be specified
@@ -213,7 +213,7 @@ module Fluent
           raise Fluent::ConfigError, "'table' or 'tables' must be specified, and both are invalid"
         end
 
-        @tablelist = @tables ? @tables.split(',') : [@table]
+        @tablelist = @tables ? @tables : [@table]
 
         @fields = Fluent::BigQuery::RecordSchema.new('record')
         if @schema_path
@@ -222,9 +222,9 @@ module Fluent
 
         types = %w(string integer float boolean timestamp)
         types.each do |type|
-          raw_fields = instance_variable_get("@field_#{type}")
-          next unless raw_fields
-          raw_fields.split(',').each do |field|
+          fields = instance_variable_get("@field_#{type}")
+          next unless fields
+          fields.each do |field|
             @fields.register_field field.strip, type.to_sym
           end
         end

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -188,8 +188,6 @@ module Fluent
         when :load
           raise Fluent::ConfigError, "'template_suffix' is for only `insert` mode, instead use 'fetch_schema_table' and formatted table name" if @template_suffix
           extend(LoadImplementation)
-        else
-          raise Fluent::ConfigError "'method' must be 'insert' or 'load'"
         end
 
         case @auth_method

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -18,7 +18,7 @@ module Fluent
 
       ### default for insert
       def configure_for_insert(conf)
-        raise ConfigError unless conf["method"] != "load"
+        raise ConfigError unless conf["method"].nil? || conf["method"] == "insert"
 
         buffer_config = conf.elements("buffer")[0]
         return unless buffer_config

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -13,486 +13,488 @@ require 'fluent/plugin/bigquery/writer'
 # require 'fluent/plugin/bigquery/load_request_body_wrapper'
 
 module Fluent
-  class BigQueryOutput < TimeSlicedOutput
-    Fluent::Plugin.register_output('bigquery', self)
+  module Plugin
+    class BigQueryOutput < Output
+      Fluent::Plugin.register_output('bigquery', self)
 
-    # https://developers.google.com/bigquery/browser-tool-quickstart
-    # https://developers.google.com/bigquery/bigquery-api-quickstart
+      # https://developers.google.com/bigquery/browser-tool-quickstart
+      # https://developers.google.com/bigquery/bigquery-api-quickstart
 
-    ### default for insert
-    def configure_for_insert(conf)
-      raise ConfigError unless conf["method"] != "load"
+      ### default for insert
+      def configure_for_insert(conf)
+        raise ConfigError unless conf["method"] != "load"
 
-      conf["buffer_type"]                = "lightening"  unless conf["buffer_type"]
-      conf["flush_interval"]             = 0.25          unless conf["flush_interval"]
-      conf["try_flush_interval"]         = 0.05          unless conf["try_flush_interval"]
-      conf["buffer_chunk_limit"]         = 1 * 1024 ** 2 unless conf["buffer_chunk_limit"] # 1MB
-      conf["buffer_queue_limit"]         = 1024          unless conf["buffer_queue_limit"]
-      conf["buffer_chunk_records_limit"] = 500           unless conf["buffer_chunk_records_limit"]
-    end
-
-    ### default for loads
-    def configure_for_load(conf)
-      raise ConfigError unless conf["method"] == "load"
-
-      # buffer_type, flush_interval, try_flush_interval is TimeSlicedOutput default
-      conf["buffer_chunk_limit"] = 1 * 1024 ** 3 unless conf["buffer_chunk_limit"] # 1GB
-      conf["buffer_queue_limit"] = 32            unless conf["buffer_queue_limit"]
-    end
-
-    # Available methods are:
-    # * private_key -- Use service account credential from pkcs12 private key file
-    # * compute_engine -- Use access token available in instances of ComputeEngine
-    # * json_key -- Use service account credential from JSON key
-    # * application_default -- Use application default credential
-    config_param :auth_method, :enum, list: [:private_key, :compute_engine, :json_key, :application_default], default: :private_key
-
-    ### Service Account credential
-    config_param :email, :string, default: nil
-    config_param :private_key_path, :string, default: nil
-    config_param :private_key_passphrase, :string, default: 'notasecret', secret: true
-    config_param :json_key, default: nil, secret: true
-
-    # see as simple reference
-    #   https://github.com/abronte/BigQuery/blob/master/lib/bigquery.rb
-    config_param :project, :string
-
-    # dataset_name
-    #   The name can be up to 1,024 characters long, and consist of A-Z, a-z, 0-9, and the underscore,
-    #   but it cannot start with a number or underscore, or have spaces.
-    config_param :dataset, :string
-
-    # table_id
-    #   In Table ID, enter a name for your new table. Naming rules are the same as for your dataset.
-    config_param :table, :string, default: nil
-    config_param :tables, :string, default: nil # TODO: use :array with value_type: :string
-
-    # template_suffix (only insert)
-    #   https://cloud.google.com/bigquery/streaming-data-into-bigquery#template_table_details
-    config_param :template_suffix, :string, default: nil
-
-    config_param :auto_create_table, :bool, default: false
-
-    # skip_invalid_rows (only insert)
-    #   Insert all valid rows of a request, even if invalid rows exist.
-    #   The default value is false, which causes the entire request to fail if any invalid rows exist.
-    config_param :skip_invalid_rows, :bool, default: false
-    # max_bad_records (only load)
-    #   The maximum number of bad records that BigQuery can ignore when running the job.
-    #   If the number of bad records exceeds this value, an invalid error is returned in the job result.
-    #   The default value is 0, which requires that all records are valid.
-    config_param :max_bad_records, :integer, default: 0
-    # ignore_unknown_values
-    #   Accept rows that contain values that do not match the schema. The unknown values are ignored.
-    #   Default is false, which treats unknown values as errors.
-    config_param :ignore_unknown_values, :bool, default: false
-
-    config_param :schema_path, :string, default: nil
-    config_param :fetch_schema, :bool, default: false
-    config_param :fetch_schema_table, :string, default: nil
-    config_param :schema_cache_expire, :time, default: 600
-    config_param :field_string,  :string, default: nil
-    config_param :field_integer, :string, default: nil
-    config_param :field_float,   :string, default: nil
-    config_param :field_boolean, :string, default: nil
-    config_param :field_timestamp, :string, default: nil
-    ### TODO: record field stream inserts doesn't works well?
-    ###  At table creation, table type json + field type record -> field type validation fails
-    ###  At streaming inserts, schema cannot be specified
-    # config_param :field_record,  :string, defualt: nil
-    # config_param :optional_data_field, :string, default: nil
-
-    REGEXP_MAX_NUM = 10
-    config_param :replace_record_key, :bool, default: false
-    (1..REGEXP_MAX_NUM).each {|i| config_param :"replace_record_key_regexp#{i}", :string, default: nil }
-
-    config_param :convert_hash_to_json, :bool, default: false
-
-    config_param :time_format, :string, default: nil
-    config_param :localtime, :bool, default: nil
-    config_param :utc, :bool, default: nil
-    config_param :time_field, :string, default: nil
-
-    # insert_id_field (only insert)
-    config_param :insert_id_field, :string, default: nil
-    # prevent_duplicate_load (only load)
-    config_param :prevent_duplicate_load, :bool, default: false
-
-    config_param :method, :enum, list: [:insert, :load], default: :insert, skip_accessor: true
-
-    # TODO
-    # config_param :row_size_limit, :integer, default: 100*1000 # < 100KB # configurable in google ?
-    # config_param :insert_size_limit, :integer, default: 1000**2 # < 1MB
-    # config_param :rows_per_second_limit, :integer, default: 1000 # spike limit
-    ### method: ''Streaming data inserts support
-    #  https://developers.google.com/bigquery/streaming-data-into-bigquery#usecases
-    # Maximum row size: 100 KB
-    # Maximum data size of all rows, per insert: 1 MB
-    # Maximum rows per second: 100 rows per second, per table, with allowed and occasional bursts of up to 1,000 rows per second.
-    #                          If you exceed 100 rows per second for an extended period of time, throttling might occur.
-    ### Toooooooooooooo short/small per inserts and row!
-
-    ## Timeout
-    # request_timeout_sec
-    #   Bigquery API response timeout
-    # request_open_timeout_sec
-    #   Bigquery API connection, and request timeout
-    config_param :request_timeout_sec, :time, default: nil
-    config_param :request_open_timeout_sec, :time, default: 60
-
-    ## Partitioning
-    config_param :time_partitioning_type, :enum, list: [:day], default: nil
-    config_param :time_partitioning_expiration, :time, default: nil
-
-    ### Table types
-    # https://developers.google.com/bigquery/docs/tables
-    #
-    # type - The following data types are supported; see Data Formats for details on each data type:
-    # STRING
-    # INTEGER
-    # FLOAT
-    # BOOLEAN
-    # RECORD A JSON object, used when importing nested records. This type is only available when using JSON source files.
-    #
-    # mode - Whether a field can be null. The following values are supported:
-    # NULLABLE - The cell can be null.
-    # REQUIRED - The cell cannot be null.
-    # REPEATED - Zero or more repeated simple or nested subfields. This mode is only supported when using JSON source files.
-
-    def initialize
-      super
-      require 'multi_json'
-      require 'google/apis/bigquery_v2'
-      require 'googleauth'
-      require 'active_support/json'
-      require 'active_support/core_ext/hash'
-      require 'active_support/core_ext/object/json'
-
-      # MEMO: signet-0.6.1 depend on Farady.default_connection
-      Faraday.default_connection.options.timeout = 60
-    end
-
-    def configure(conf)
-      if conf["method"] == "load"
-        configure_for_load(conf)
-      else
-        configure_for_insert(conf)
-      end
-      super
-
-      case @method
-      when :insert
-        extend(InsertImplementation)
-      when :load
-        raise Fluent::ConfigError, "'template_suffix' is for only `insert` mode, instead use 'fetch_schema_table' and formatted table name" if @template_suffix
-        extend(LoadImplementation)
-      else
-        raise Fluent::ConfigError "'method' must be 'insert' or 'load'"
+        conf["buffer_type"]                = "lightening"  unless conf["buffer_type"]
+        conf["flush_interval"]             = 0.25          unless conf["flush_interval"]
+        conf["try_flush_interval"]         = 0.05          unless conf["try_flush_interval"]
+        conf["buffer_chunk_limit"]         = 1 * 1024 ** 2 unless conf["buffer_chunk_limit"] # 1MB
+        conf["buffer_queue_limit"]         = 1024          unless conf["buffer_queue_limit"]
+        conf["buffer_chunk_records_limit"] = 500           unless conf["buffer_chunk_records_limit"]
       end
 
-      case @auth_method
-      when :private_key
-        unless @email && @private_key_path
-          raise Fluent::ConfigError, "'email' and 'private_key_path' must be specified if auth_method == 'private_key'"
+      ### default for loads
+      def configure_for_load(conf)
+        raise ConfigError unless conf["method"] == "load"
+
+        # buffer_type, flush_interval, try_flush_interval is TimeSlicedOutput default
+        conf["buffer_chunk_limit"] = 1 * 1024 ** 3 unless conf["buffer_chunk_limit"] # 1GB
+        conf["buffer_queue_limit"] = 32            unless conf["buffer_queue_limit"]
+      end
+
+      # Available methods are:
+      # * private_key -- Use service account credential from pkcs12 private key file
+      # * compute_engine -- Use access token available in instances of ComputeEngine
+      # * json_key -- Use service account credential from JSON key
+      # * application_default -- Use application default credential
+      config_param :auth_method, :enum, list: [:private_key, :compute_engine, :json_key, :application_default], default: :private_key
+
+      ### Service Account credential
+      config_param :email, :string, default: nil
+      config_param :private_key_path, :string, default: nil
+      config_param :private_key_passphrase, :string, default: 'notasecret', secret: true
+      config_param :json_key, default: nil, secret: true
+
+      # see as simple reference
+      #   https://github.com/abronte/BigQuery/blob/master/lib/bigquery.rb
+      config_param :project, :string
+
+      # dataset_name
+      #   The name can be up to 1,024 characters long, and consist of A-Z, a-z, 0-9, and the underscore,
+      #   but it cannot start with a number or underscore, or have spaces.
+      config_param :dataset, :string
+
+      # table_id
+      #   In Table ID, enter a name for your new table. Naming rules are the same as for your dataset.
+      config_param :table, :string, default: nil
+      config_param :tables, :string, default: nil # TODO: use :array with value_type: :string
+
+      # template_suffix (only insert)
+      #   https://cloud.google.com/bigquery/streaming-data-into-bigquery#template_table_details
+      config_param :template_suffix, :string, default: nil
+
+      config_param :auto_create_table, :bool, default: false
+
+      # skip_invalid_rows (only insert)
+      #   Insert all valid rows of a request, even if invalid rows exist.
+      #   The default value is false, which causes the entire request to fail if any invalid rows exist.
+      config_param :skip_invalid_rows, :bool, default: false
+      # max_bad_records (only load)
+      #   The maximum number of bad records that BigQuery can ignore when running the job.
+      #   If the number of bad records exceeds this value, an invalid error is returned in the job result.
+      #   The default value is 0, which requires that all records are valid.
+      config_param :max_bad_records, :integer, default: 0
+      # ignore_unknown_values
+      #   Accept rows that contain values that do not match the schema. The unknown values are ignored.
+      #   Default is false, which treats unknown values as errors.
+      config_param :ignore_unknown_values, :bool, default: false
+
+      config_param :schema_path, :string, default: nil
+      config_param :fetch_schema, :bool, default: false
+      config_param :fetch_schema_table, :string, default: nil
+      config_param :schema_cache_expire, :time, default: 600
+      config_param :field_string,  :string, default: nil
+      config_param :field_integer, :string, default: nil
+      config_param :field_float,   :string, default: nil
+      config_param :field_boolean, :string, default: nil
+      config_param :field_timestamp, :string, default: nil
+      ### TODO: record field stream inserts doesn't works well?
+      ###  At table creation, table type json + field type record -> field type validation fails
+      ###  At streaming inserts, schema cannot be specified
+      # config_param :field_record,  :string, defualt: nil
+      # config_param :optional_data_field, :string, default: nil
+
+      REGEXP_MAX_NUM = 10
+      config_param :replace_record_key, :bool, default: false
+      (1..REGEXP_MAX_NUM).each {|i| config_param :"replace_record_key_regexp#{i}", :string, default: nil }
+
+      config_param :convert_hash_to_json, :bool, default: false
+
+      config_param :time_format, :string, default: nil
+      config_param :localtime, :bool, default: nil
+      config_param :utc, :bool, default: nil
+      config_param :time_field, :string, default: nil
+
+      # insert_id_field (only insert)
+      config_param :insert_id_field, :string, default: nil
+      # prevent_duplicate_load (only load)
+      config_param :prevent_duplicate_load, :bool, default: false
+
+      config_param :method, :enum, list: [:insert, :load], default: :insert, skip_accessor: true
+
+      # TODO
+      # config_param :row_size_limit, :integer, default: 100*1000 # < 100KB # configurable in google ?
+      # config_param :insert_size_limit, :integer, default: 1000**2 # < 1MB
+      # config_param :rows_per_second_limit, :integer, default: 1000 # spike limit
+      ### method: ''Streaming data inserts support
+      #  https://developers.google.com/bigquery/streaming-data-into-bigquery#usecases
+      # Maximum row size: 100 KB
+      # Maximum data size of all rows, per insert: 1 MB
+      # Maximum rows per second: 100 rows per second, per table, with allowed and occasional bursts of up to 1,000 rows per second.
+      #                          If you exceed 100 rows per second for an extended period of time, throttling might occur.
+      ### Toooooooooooooo short/small per inserts and row!
+
+      ## Timeout
+      # request_timeout_sec
+      #   Bigquery API response timeout
+      # request_open_timeout_sec
+      #   Bigquery API connection, and request timeout
+      config_param :request_timeout_sec, :time, default: nil
+      config_param :request_open_timeout_sec, :time, default: 60
+
+      ## Partitioning
+      config_param :time_partitioning_type, :enum, list: [:day], default: nil
+      config_param :time_partitioning_expiration, :time, default: nil
+
+      ### Table types
+      # https://developers.google.com/bigquery/docs/tables
+      #
+      # type - The following data types are supported; see Data Formats for details on each data type:
+      # STRING
+      # INTEGER
+      # FLOAT
+      # BOOLEAN
+      # RECORD A JSON object, used when importing nested records. This type is only available when using JSON source files.
+      #
+      # mode - Whether a field can be null. The following values are supported:
+      # NULLABLE - The cell can be null.
+      # REQUIRED - The cell cannot be null.
+      # REPEATED - Zero or more repeated simple or nested subfields. This mode is only supported when using JSON source files.
+
+      def initialize
+        super
+        require 'multi_json'
+        require 'google/apis/bigquery_v2'
+        require 'googleauth'
+        require 'active_support/json'
+        require 'active_support/core_ext/hash'
+        require 'active_support/core_ext/object/json'
+
+        # MEMO: signet-0.6.1 depend on Farady.default_connection
+        Faraday.default_connection.options.timeout = 60
+      end
+
+      def configure(conf)
+        if conf["method"] == "load"
+          configure_for_load(conf)
+        else
+          configure_for_insert(conf)
         end
-      when :compute_engine
-        # Do nothing
-      when :json_key
-        unless @json_key
-          raise Fluent::ConfigError, "'json_key' must be specified if auth_method == 'json_key'"
+        super
+
+        case @method
+        when :insert
+          extend(InsertImplementation)
+        when :load
+          raise Fluent::ConfigError, "'template_suffix' is for only `insert` mode, instead use 'fetch_schema_table' and formatted table name" if @template_suffix
+          extend(LoadImplementation)
+        else
+          raise Fluent::ConfigError "'method' must be 'insert' or 'load'"
         end
-      when :application_default
-        # Do nothing
-      else
-        raise Fluent::ConfigError, "unrecognized 'auth_method': #{@auth_method}"
-      end
 
-      unless @table.nil? ^ @tables.nil?
-        raise Fluent::ConfigError, "'table' or 'tables' must be specified, and both are invalid"
-      end
-
-      @tablelist = @tables ? @tables.split(',') : [@table]
-
-      @fields = Fluent::BigQuery::RecordSchema.new('record')
-      if @schema_path
-        @fields.load_schema(MultiJson.load(File.read(@schema_path)))
-      end
-
-      types = %w(string integer float boolean timestamp)
-      types.each do |type|
-        raw_fields = instance_variable_get("@field_#{type}")
-        next unless raw_fields
-        raw_fields.split(',').each do |field|
-          @fields.register_field field.strip, type.to_sym
+        case @auth_method
+        when :private_key
+          unless @email && @private_key_path
+            raise Fluent::ConfigError, "'email' and 'private_key_path' must be specified if auth_method == 'private_key'"
+          end
+        when :compute_engine
+          # Do nothing
+        when :json_key
+          unless @json_key
+            raise Fluent::ConfigError, "'json_key' must be specified if auth_method == 'json_key'"
+          end
+        when :application_default
+          # Do nothing
+        else
+          raise Fluent::ConfigError, "unrecognized 'auth_method': #{@auth_method}"
         end
-      end
 
-      @regexps = {}
-      (1..REGEXP_MAX_NUM).each do |i|
-        next unless conf["replace_record_key_regexp#{i}"]
-        regexp, replacement = conf["replace_record_key_regexp#{i}"].split(/ /, 2)
-        raise ConfigError, "replace_record_key_regexp#{i} does not contain 2 parameters" unless replacement
-        raise ConfigError, "replace_record_key_regexp#{i} contains a duplicated key, #{regexp}" if @regexps[regexp]
-        @regexps[regexp] = replacement
-      end
+        unless @table.nil? ^ @tables.nil?
+          raise Fluent::ConfigError, "'table' or 'tables' must be specified, and both are invalid"
+        end
 
-      @localtime = false if @localtime.nil? && @utc
+        @tablelist = @tables ? @tables.split(',') : [@table]
 
-      @timef = TimeFormatter.new(@time_format, @localtime)
+        @fields = Fluent::BigQuery::RecordSchema.new('record')
+        if @schema_path
+          @fields.load_schema(MultiJson.load(File.read(@schema_path)))
+        end
 
-      if @time_field
-        keys = @time_field.split('.')
-        last_key = keys.pop
-        @add_time_field = ->(record, time) {
-          keys.inject(record) { |h, k| h[k] ||= {} }[last_key] = @timef.format(time)
-          record
-        }
-      else
-        @add_time_field = ->(record, time) { record }
-      end
+        types = %w(string integer float boolean timestamp)
+        types.each do |type|
+          raw_fields = instance_variable_get("@field_#{type}")
+          next unless raw_fields
+          raw_fields.split(',').each do |field|
+            @fields.register_field field.strip, type.to_sym
+          end
+        end
 
-      if @insert_id_field
-        insert_id_keys = @insert_id_field.split('.')
-        @get_insert_id = ->(record) {
-          insert_id_keys.inject(record) {|h, k| h[k] }
-        }
-      else
-        @get_insert_id = nil
-      end
-    end
+        @regexps = {}
+        (1..REGEXP_MAX_NUM).each do |i|
+          next unless conf["replace_record_key_regexp#{i}"]
+          regexp, replacement = conf["replace_record_key_regexp#{i}"].split(/ /, 2)
+          raise ConfigError, "replace_record_key_regexp#{i} does not contain 2 parameters" unless replacement
+          raise ConfigError, "replace_record_key_regexp#{i} contains a duplicated key, #{regexp}" if @regexps[regexp]
+          @regexps[regexp] = replacement
+        end
 
-    def start
-      super
+        @localtime = false if @localtime.nil? && @utc
 
-      @tables_queue = @tablelist.dup.shuffle
-      @tables_mutex = Mutex.new
-      @fetch_schema_mutex = Mutex.new
+        @timef = TimeFormatter.new(@time_format, @localtime)
 
-      @last_fetch_schema_time = 0
-      fetch_schema(false) if @fetch_schema
-    end
+        if @time_field
+          keys = @time_field.split('.')
+          last_key = keys.pop
+          @add_time_field = ->(record, time) {
+            keys.inject(record) { |h, k| h[k] ||= {} }[last_key] = @timef.format(time)
+            record
+          }
+        else
+          @add_time_field = ->(record, time) { record }
+        end
 
-    def writer
-      @writer ||= Fluent::BigQuery::Writer.new(@log, @auth_method, {
-        private_key_path: @private_key_path, private_key_passphrase: @private_key_passphrase,
-        email: @email,
-        json_key: @json_key,
-      })
-    end
-
-    def generate_table_id(table_id_format, current_time, row = nil, chunk = nil)
-      format, col = table_id_format.split(/@/)
-      time = if col && row
-               keys = col.split('.')
-               t = keys.inject(row[:json]) {|obj, attr| obj[attr.to_sym] }
-               Time.at(t)
-             else
-               current_time
-             end
-      if row && format =~ /\$\{/
-        format.gsub!(/\$\{\s*(\w+)\s*\}/) do |m|
-          row[:json][$1.to_sym].to_s.gsub(/[^\w]/, '')
+        if @insert_id_field
+          insert_id_keys = @insert_id_field.split('.')
+          @get_insert_id = ->(record) {
+            insert_id_keys.inject(record) {|h, k| h[k] }
+          }
+        else
+          @get_insert_id = nil
         end
       end
-      table_id = time.strftime(format)
 
-      if chunk
-        table_id.gsub(%r(%{time_slice})) { |expr|
-          chunk.key
-        }
-      else
-        table_id.gsub(%r(%{time_slice})) { |expr|
-          current_time.strftime(@time_slice_format)
-        }
+      def start
+        super
+
+        @tables_queue = @tablelist.dup.shuffle
+        @tables_mutex = Mutex.new
+        @fetch_schema_mutex = Mutex.new
+
+        @last_fetch_schema_time = 0
+        fetch_schema(false) if @fetch_schema
       end
-    end
 
-    def replace_record_key(record)
-      new_record = {}
-      record.each do |key, _|
-        new_key = key
-        @regexps.each do |regexp, replacement|
-          new_key = new_key.gsub(/#{regexp}/, replacement)
+      def writer
+        @writer ||= Fluent::BigQuery::Writer.new(@log, @auth_method, {
+          private_key_path: @private_key_path, private_key_passphrase: @private_key_passphrase,
+          email: @email,
+          json_key: @json_key,
+        })
+      end
+
+      def generate_table_id(table_id_format, current_time, row = nil, chunk = nil)
+        format, col = table_id_format.split(/@/)
+        time = if col && row
+                 keys = col.split('.')
+                 t = keys.inject(row[:json]) {|obj, attr| obj[attr.to_sym] }
+                 Time.at(t)
+               else
+                 current_time
+               end
+        if row && format =~ /\$\{/
+          format.gsub!(/\$\{\s*(\w+)\s*\}/) do |m|
+            row[:json][$1.to_sym].to_s.gsub(/[^\w]/, '')
+          end
         end
-        new_key = new_key.gsub(/\W/, '')
-        new_record.store(new_key, record[key])
-      end
-      new_record
-    end
+        table_id = time.strftime(format)
 
-    def convert_hash_to_json(record)
-      record.each do |key, value|
-        if value.class == Hash
-          record[key] = MultiJson.dump(value)
+        if chunk
+          table_id.gsub(%r(%{time_slice})) { |expr|
+            chunk.key
+          }
+        else
+          table_id.gsub(%r(%{time_slice})) { |expr|
+            current_time.strftime(@time_slice_format)
+          }
         end
       end
-      record
-    end
 
-    def write(chunk)
-      table_id_format = @tables_mutex.synchronize do
-        t = @tables_queue.shift
-        @tables_queue.push t
-        t
+      def replace_record_key(record)
+        new_record = {}
+        record.each do |key, _|
+          new_key = key
+          @regexps.each do |regexp, replacement|
+            new_key = new_key.gsub(/#{regexp}/, replacement)
+          end
+          new_key = new_key.gsub(/\W/, '')
+          new_record.store(new_key, record[key])
+        end
+        new_record
       end
-      template_suffix_format = @template_suffix
-      _write(chunk, table_id_format, template_suffix_format)
-    end
 
-    def fetch_schema(allow_overwrite = true)
-      table_id = nil
-      @fetch_schema_mutex.synchronize do
-        if Fluent::Engine.now - @last_fetch_schema_time > @schema_cache_expire
-          table_id_format = @fetch_schema_table || @tablelist[0]
-          table_id = generate_table_id(table_id_format, Time.at(Fluent::Engine.now))
-          schema = writer.fetch_schema(@project, @dataset, table_id)
+      def convert_hash_to_json(record)
+        record.each do |key, value|
+          if value.class == Hash
+            record[key] = MultiJson.dump(value)
+          end
+        end
+        record
+      end
 
-          if schema
-            if allow_overwrite
-              fields = Fluent::BigQuery::RecordSchema.new("record")
-              fields.load_schema(schema, allow_overwrite)
-              @fields = fields
+      def write(chunk)
+        table_id_format = @tables_mutex.synchronize do
+          t = @tables_queue.shift
+          @tables_queue.push t
+          t
+        end
+        template_suffix_format = @template_suffix
+        _write(chunk, table_id_format, template_suffix_format)
+      end
+
+      def fetch_schema(allow_overwrite = true)
+        table_id = nil
+        @fetch_schema_mutex.synchronize do
+          if Fluent::Engine.now - @last_fetch_schema_time > @schema_cache_expire
+            table_id_format = @fetch_schema_table || @tablelist[0]
+            table_id = generate_table_id(table_id_format, Time.at(Fluent::Engine.now))
+            schema = writer.fetch_schema(@project, @dataset, table_id)
+
+            if schema
+              if allow_overwrite
+                fields = Fluent::BigQuery::RecordSchema.new("record")
+                fields.load_schema(schema, allow_overwrite)
+                @fields = fields
+              else
+                @fields.load_schema(schema, allow_overwrite)
+              end
             else
-              @fields.load_schema(schema, allow_overwrite)
+              if @fields.empty?
+                raise "failed to fetch schema from bigquery"
+              else
+                log.warn "#{table_id} uses previous schema"
+              end
+            end
+
+            @last_fetch_schema_time = Fluent::Engine.now
+          end
+        end
+      end
+
+      module InsertImplementation
+        def format(tag, time, record)
+          fetch_schema if @template_suffix
+
+          if @replace_record_key
+            record = replace_record_key(record)
+          end
+
+          if @convert_hash_to_json
+            record = convert_hash_to_json(record)
+          end
+
+          buf = String.new
+          row = @fields.format(@add_time_field.call(record, time))
+          unless row.empty?
+            row = {"json" => row}
+            row['insert_id'] = @get_insert_id.call(record) if @get_insert_id
+            buf << row.to_msgpack
+          end
+          buf
+        end
+
+        def _write(chunk, table_format, template_suffix_format)
+          rows = []
+          chunk.msgpack_each do |row_object|
+            # TODO: row size limit
+            rows << row_object.deep_symbolize_keys
+          end
+
+          now = Time.at(Fluent::Engine.now)
+          group = rows.group_by do |row|
+            [
+              generate_table_id(table_format, now, row, chunk),
+              template_suffix_format ? generate_table_id(template_suffix_format, now, row, chunk) : nil,
+            ]
+          end
+          group.each do |(table_id, template_suffix), group_rows|
+            insert(table_id, group_rows, template_suffix)
+          end
+        end
+
+        def insert(table_id, rows, template_suffix)
+          writer.insert_rows(@project, @dataset, table_id, rows, skip_invalid_rows: @skip_invalid_rows, ignore_unknown_values: @ignore_unknown_values, template_suffix: template_suffix)
+        rescue Fluent::BigQuery::Error => e
+          if @auto_create_table && e.status_code == 404 && /Not Found: Table/i =~ e.message
+            # Table Not Found: Auto Create Table
+            writer.create_table(@project, @dataset, table_id, @fields, time_partitioning_type: @time_partitioning_type, time_partitioning_expiration: @time_partitioning_expiration)
+            raise "table created. send rows next time."
+          end
+
+          if e.retryable?
+            raise e # TODO: error class
+          elsif @secondary
+            flush_secondary(@secondary)
+          end
+        end
+      end
+
+      module LoadImplementation
+        def format(tag, time, record)
+          fetch_schema if @fetch_schema_table
+
+          if @replace_record_key
+            record = replace_record_key(record)
+          end
+
+          buf = String.new
+          row = @fields.format(@add_time_field.call(record, time))
+          unless row.empty?
+            buf << MultiJson.dump(row) + "\n"
+          end
+          buf
+        end
+
+        def _write(chunk, table_id_format, _)
+          now = Time.at(Fluent::Engine.now)
+          table_id = generate_table_id(table_id_format, now, nil, chunk)
+          load(chunk, table_id)
+        end
+
+        def load(chunk, table_id)
+          res = nil
+
+          if @prevent_duplicate_load
+            job_id = create_job_id(chunk, @dataset, table_id, @fields.to_a, @max_bad_records, @ignore_unknown_values)
+          else
+            job_id = nil
+          end
+
+          create_upload_source(chunk) do |upload_source|
+            res = writer.create_load_job(@project, @dataset, table_id, upload_source, job_id, @fields, {
+              ignore_unknown_values: @ignore_unknown_values, max_bad_records: @max_bad_records,
+              timeout_sec: @request_timeout_sec,  open_timeout_sec: @request_open_timeout_sec, auto_create_table: @auto_create_table,
+              time_partitioning_type: @time_partitioning_type, time_partitioning_expiration: @time_partitioning_expiration
+            })
+          end
+        rescue Fluent::BigQuery::Error => e
+          if e.retryable?
+            raise e
+          elsif @secondary
+            flush_secondary(@secondary)
+          end
+        end
+
+        private
+
+        def create_upload_source(chunk)
+          chunk_is_file = @buffer_type == 'file'
+          if chunk_is_file
+            File.open(chunk.path) do |file|
+              yield file
             end
           else
-            if @fields.empty?
-              raise "failed to fetch schema from bigquery"
-            else
-              log.warn "#{table_id} uses previous schema"
+            Tempfile.open("chunk-tmp") do |file|
+              file.binmode
+              chunk.write_to(file)
+              file.sync
+              file.rewind
+              yield file
             end
           end
-
-          @last_fetch_schema_time = Fluent::Engine.now
-        end
-      end
-    end
-
-    module InsertImplementation
-      def format(tag, time, record)
-        fetch_schema if @template_suffix
-
-        if @replace_record_key
-          record = replace_record_key(record)
         end
 
-        if @convert_hash_to_json
-          record = convert_hash_to_json(record)
+        def create_job_id(chunk, dataset, table, schema, max_bad_records, ignore_unknown_values)
+          "fluentd_job_" + Digest::SHA1.hexdigest("#{chunk.unique_id}#{dataset}#{table}#{schema.to_s}#{max_bad_records}#{ignore_unknown_values}")
         end
-
-        buf = String.new
-        row = @fields.format(@add_time_field.call(record, time))
-        unless row.empty?
-          row = {"json" => row}
-          row['insert_id'] = @get_insert_id.call(record) if @get_insert_id
-          buf << row.to_msgpack
-        end
-        buf
-      end
-
-      def _write(chunk, table_format, template_suffix_format)
-        rows = []
-        chunk.msgpack_each do |row_object|
-          # TODO: row size limit
-          rows << row_object.deep_symbolize_keys
-        end
-
-        now = Time.at(Fluent::Engine.now)
-        group = rows.group_by do |row|
-          [
-            generate_table_id(table_format, now, row, chunk),
-            template_suffix_format ? generate_table_id(template_suffix_format, now, row, chunk) : nil,
-          ]
-        end
-        group.each do |(table_id, template_suffix), group_rows|
-          insert(table_id, group_rows, template_suffix)
-        end
-      end
-
-      def insert(table_id, rows, template_suffix)
-        writer.insert_rows(@project, @dataset, table_id, rows, skip_invalid_rows: @skip_invalid_rows, ignore_unknown_values: @ignore_unknown_values, template_suffix: template_suffix)
-      rescue Fluent::BigQuery::Error => e
-        if @auto_create_table && e.status_code == 404 && /Not Found: Table/i =~ e.message
-          # Table Not Found: Auto Create Table
-          writer.create_table(@project, @dataset, table_id, @fields, time_partitioning_type: @time_partitioning_type, time_partitioning_expiration: @time_partitioning_expiration)
-          raise "table created. send rows next time."
-        end
-
-        if e.retryable?
-          raise e # TODO: error class
-        elsif @secondary
-          flush_secondary(@secondary)
-        end
-      end
-    end
-
-    module LoadImplementation
-      def format(tag, time, record)
-        fetch_schema if @fetch_schema_table
-
-        if @replace_record_key
-          record = replace_record_key(record)
-        end
-
-        buf = String.new
-        row = @fields.format(@add_time_field.call(record, time))
-        unless row.empty?
-          buf << MultiJson.dump(row) + "\n"
-        end
-        buf
-      end
-
-      def _write(chunk, table_id_format, _)
-        now = Time.at(Fluent::Engine.now)
-        table_id = generate_table_id(table_id_format, now, nil, chunk)
-        load(chunk, table_id)
-      end
-
-      def load(chunk, table_id)
-        res = nil
-
-        if @prevent_duplicate_load
-          job_id = create_job_id(chunk, @dataset, table_id, @fields.to_a, @max_bad_records, @ignore_unknown_values)
-        else
-          job_id = nil
-        end
-
-        create_upload_source(chunk) do |upload_source|
-          res = writer.create_load_job(@project, @dataset, table_id, upload_source, job_id, @fields, {
-            ignore_unknown_values: @ignore_unknown_values, max_bad_records: @max_bad_records,
-            timeout_sec: @request_timeout_sec,  open_timeout_sec: @request_open_timeout_sec, auto_create_table: @auto_create_table,
-            time_partitioning_type: @time_partitioning_type, time_partitioning_expiration: @time_partitioning_expiration
-          })
-        end
-      rescue Fluent::BigQuery::Error => e
-        if e.retryable?
-          raise e
-        elsif @secondary
-          flush_secondary(@secondary)
-        end
-      end
-
-      private
-
-      def create_upload_source(chunk)
-        chunk_is_file = @buffer_type == 'file'
-        if chunk_is_file
-          File.open(chunk.path) do |file|
-            yield file
-          end
-        else
-          Tempfile.open("chunk-tmp") do |file|
-            file.binmode
-            chunk.write_to(file)
-            file.sync
-            file.rewind
-            yield file
-          end
-        end
-      end
-
-      def create_job_id(chunk, dataset, table, schema, max_bad_records, ignore_unknown_values)
-        "fluentd_job_" + Digest::SHA1.hexdigest("#{chunk.unique_id}#{dataset}#{table}#{schema.to_s}#{max_bad_records}#{ignore_unknown_values}")
       end
     end
   end

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -315,12 +315,6 @@ module Fluent
         _write(chunk, table_id_format, template_suffix_format)
       end
 
-      # for delayed commit
-      def try_write(chunk)
-        write(chunk)
-        commit_write(chunk.unique_id, delayed: true)
-      end
-
       def fetch_schema(allow_overwrite = true)
         table_id = nil
         @fetch_schema_mutex.synchronize do

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -449,7 +449,23 @@ module Fluent
           if e.retryable?
             raise e
           elsif @secondary
-            flush_secondary(@secondary)
+            # TODO: find better way
+            @retry = retry_state_create(
+              :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
+              forever: false, max_steps: @buffer_config.retry_max_times, backoff_base: @buffer_config.retry_exponential_backoff_base,
+              max_interval: @buffer_config.retry_max_interval,
+              secondary: true, secondary_threshold: 0.00000000001,
+              randomize: @buffer_config.retry_randomize
+            )
+            raise e
+          else
+            @retry = retry_state_create(
+              :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
+              forever: false, max_steps: 0, backoff_base: @buffer_config.retry_exponential_backoff_base,
+              max_interval: @buffer_config.retry_max_interval,
+              randomize: @buffer_config.retry_randomize
+            )
+            raise e
           end
         end
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -312,6 +312,10 @@ module Fluent
           record = replace_record_key(record)
         end
 
+        if @convert_hash_to_json
+          record = convert_hash_to_json(record)
+        end
+
         buf = String.new
         row = @fields.format(@add_time_field.call(record, time))
         unless row.empty?

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -42,7 +42,7 @@ module Fluent
       def configure_for_load(conf)
         raise ConfigError unless conf["method"] == "load"
 
-        buffer_config = conf.elements("buffer")
+        buffer_config = conf.elements("buffer")[0]
         return unless buffer_config
         buffer_config["@type"]                       = "file"        unless buffer_config["@type"]
         buffer_config["flush_mode"]                  = :interval     unless buffer_config["flush_mode"]
@@ -422,7 +422,7 @@ module Fluent
 
       module LoadImplementation
         def _write(chunk, table_id_format, _)
-          table_id = extract_placeholders(table_id_format, chunk)
+          table_id = extract_placeholders(table_id_format, chunk.metadata)
           load(chunk, table_id)
         end
 
@@ -453,7 +453,7 @@ module Fluent
         private
 
         def create_upload_source(chunk)
-          chunk_is_file = @buffer_type == 'file'
+          chunk_is_file = @buffer_config["@type"] == 'file'
           if chunk_is_file
             File.open(chunk.path) do |file|
               yield file

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -28,7 +28,7 @@ module Fluent
         buffer_config["flush_thread_interval"]       = 0.05          unless buffer_config["flush_thread_interval"]
         buffer_config["flush_thread_burst_interval"] = 0.05          unless buffer_config["flush_thread_burst_interval"]
         buffer_config["chunk_limit_size"]            = 1 * 1024 ** 2 unless buffer_config["chunk_limit_size"] # 1MB
-        buffer_config["queue_length_limit"]          = 1024          unless buffer_config["queue_length_limit"]
+        buffer_config["total_limit_size"]            = 1 * 1024 ** 3 unless buffer_config["total_limit_size"] # 1GB
         buffer_config["chunk_records_limit"]         = 500           unless buffer_config["chunk_records_limit"]
       end
 
@@ -38,10 +38,10 @@ module Fluent
 
         buffer_config = conf.elements("buffer")[0]
         return unless buffer_config
-        buffer_config["@type"]                       = "file"        unless buffer_config["@type"]
-        buffer_config["flush_mode"]                  = :interval     unless buffer_config["flush_mode"]
-        buffer_config["chunk_limit_size"]            = 1 * 1024 ** 3 unless buffer_config["chunk_limit_size"] # 1GB
-        buffer_config["queue_length_limit"]          = 32            unless buffer_config["queue_length_limit"]
+        buffer_config["@type"]                       = "file"         unless buffer_config["@type"]
+        buffer_config["flush_mode"]                  = :interval      unless buffer_config["flush_mode"]
+        buffer_config["chunk_limit_size"]            = 1 * 1024 ** 3  unless buffer_config["chunk_limit_size"] # 1GB
+        buffer_config["total_limit_size"]            = 32 * 1024 ** 3 unless buffer_config["total_limit_size"] # 32GB
       end
 
       # Available methods are:

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -407,7 +407,7 @@ module Fluent
               :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
               forever: false, max_steps: @buffer_config.retry_max_times, backoff_base: @buffer_config.retry_exponential_backoff_base,
               max_interval: @buffer_config.retry_max_interval,
-              secondary: true, secondary_threshold: 0.00000000001,
+              secondary: true, secondary_threshold: Float::EPSILON,
               randomize: @buffer_config.retry_randomize
             )
             raise e
@@ -454,7 +454,7 @@ module Fluent
               :output_retries, @buffer_config.retry_type, @buffer_config.retry_wait, @buffer_config.retry_timeout,
               forever: false, max_steps: @buffer_config.retry_max_times, backoff_base: @buffer_config.retry_exponential_backoff_base,
               max_interval: @buffer_config.retry_max_interval,
-              secondary: true, secondary_threshold: 0.00000000001,
+              secondary: true, secondary_threshold: Float::EPSILON,
               randomize: @buffer_config.retry_randomize
             )
             raise e

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,11 +22,15 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
-require 'fluent/buffer'
+require 'fluent/plugin/buffer'
 require 'fluent/plugin/buf_memory'
 require 'fluent/plugin/buf_file'
+require 'fluent/test/driver/output'
 
 require 'fluent/plugin/out_bigquery'
+require 'google/apis/bigquery_v2'
+require 'google/api_client/auth/key_utils'
+require 'googleauth'
 
 require 'rr'
 require 'test/unit/rr'

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -40,7 +40,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
 
     driver = create_driver(CONFIG.sub(/\btable\s+.*$/,  'tables foo,bar'))
     assert_nil driver.instance.table
-    assert_equal driver.instance.tables, 'foo,bar'
+    assert_equal driver.instance.tables, ['foo' ,'bar']
 
     assert_raise(Fluent::ConfigError, "'table' or 'tables' must be specified, and both are invalid") {
       create_driver(CONFIG + "tables foo,bar")

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -12,8 +12,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
     project yourproject_id
     dataset yourdataset_id
 
+    <inject>
     time_format %s
-    time_field  time
+    time_key  time
+    </inject>
 
     field_integer time,status,bytes
     field_string  vhost,path,method,protocol,agent,referer,remote.host,remote.ip,remote.user
@@ -193,8 +195,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       field_integer time  , status , bytes
       field_string  _log_name, vhost, path, method, protocol, agent, referer, remote.host, remote.ip, remote.user
@@ -228,8 +232,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
     ]
 
     assert_raises(Fluent::ConfigError) do
@@ -342,8 +348,11 @@ class BigQueryOutputTest < Test::Unit::TestCase
         project yourproject_id
         dataset yourdataset_id
 
+        <inject>
         time_format #{format}
-        time_field  time
+        time_type string
+        time_key  time
+        </inject>
         #{type}     time
       CONFIG
 
@@ -353,43 +362,6 @@ class BigQueryOutputTest < Test::Unit::TestCase
 
       assert[self, expected["time"], MultiJson.load(buf)["time"]]
     end
-  end
-
-  def test_format_nested_time
-    now = Time.now
-    input = {
-      "metadata" => {
-        "node" => "mynode.example",
-      },
-      "log" => "something",
-    }
-    expected = {
-      "metadata" => {
-        "time" => now.strftime("%s").to_i,
-        "node" => "mynode.example",
-      },
-      "log" => "something",
-    }
-
-    driver = create_driver(<<-CONFIG)
-      table foo
-      email foo@bar.example
-      private_key_path /path/to/key
-      project yourproject_id
-      dataset yourdataset_id
-
-      time_format %s
-      time_field  metadata.time
-
-      field_integer metadata.time
-      field_string  metadata.node,log
-    CONFIG
-
-    driver.instance_start
-    buf = driver.instance.format("my.tag", now, input)
-    driver.instance.shutdown
-
-    assert_equal expected, MultiJson.load(buf)
   end
 
   def test_format_with_schema
@@ -459,8 +431,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "apache.schema")}
       field_integer time
@@ -494,8 +468,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "sudo.schema")}
       field_integer time
@@ -529,8 +505,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       fetch_schema true
       field_integer time
@@ -590,8 +568,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       fetch_schema true
       fetch_schema_table foo
@@ -722,8 +702,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       replace_record_key true
       replace_record_key_regexp1 - _
 
+      <inject>
       time_format %s
-      time_field time
+      time_key time
+      </inject>
 
       field_integer time
       field_string vhost, referer
@@ -768,8 +750,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
 
       convert_hash_to_json true
 
+      <inject>
       time_format %s
-      time_field time
+      time_key time
+      </inject>
 
       field_integer time
       field_string vhost, referer, remote
@@ -819,8 +803,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       field_integer time,status,bytes
       field_string  vhost,path,method,protocol,agent,referer,remote.host,remote.ip,remote.user
@@ -864,8 +850,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       field_integer time,status,bytes
       field_string  vhost,path,method,protocol,agent,referer,remote.host,remote.ip,remote.user
@@ -916,8 +904,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       schema_path #{schema_path}
       field_integer time
@@ -980,8 +970,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       schema_path #{schema_path}
       field_integer time
@@ -1047,8 +1039,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       schema_path #{schema_path}
       field_integer time
@@ -1126,8 +1120,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       schema_path #{schema_path}
       field_integer time
@@ -1270,8 +1266,10 @@ class BigQueryOutputTest < Test::Unit::TestCase
       project yourproject_id
       dataset yourdataset_id
 
+      <inject>
       time_format %s
-      time_field  time
+      time_key  time
+      </inject>
 
       auto_create_table true
       schema_path #{File.join(File.dirname(__FILE__), "testdata", "apache.schema")}

--- a/test/run_test.rb
+++ b/test/run_test.rb
@@ -1,0 +1,9 @@
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+lib_dir  = File.join(base_dir, "lib")
+test_dir = File.join(base_dir, "test")
+
+$LOAD_PATH.unshift(lib_dir)
+
+require 'test/unit'
+
+exit Test::Unit::AutoRunner.run(true, test_dir)


### PR DESCRIPTION
Support fluentd v0.14.
- Instead of `generate_table_id`, Use v0.14 chunk key placeholder.
- Remove lightening buffer, mixins.
- refactorings
