### PR TITLE
Fix logging error object not having to_msgpack

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -124,7 +124,7 @@ module Fluent
           options: {timeout_sec: timeout_sec, open_timeout_sec: open_timeout_sec}
         })
         log.debug "insert rows", project_id: project, dataset: dataset, table: table_id, count: rows.size
-        log.warn "insert errors", insert_errors: res.insert_errors if res.insert_errors && !res.insert_errors.empty?
+        log.warn "insert errors", insert_errors: res.insert_errors.to_s if res.insert_errors && !res.insert_errors.empty?
       rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e
         @client = nil
 


### PR DESCRIPTION
Fix to raise error like `error_class=NoMethodError error="undefined method 'to_msgpack' for #<Google::Apis::BigqueryV2::InsertAllTableDataResponse::InsertError>"`.
It caused by logging error object not having method `to_msgpack`.

It occurs like below configuration:

```
<match fluent.**>
    @type forward
    <server>
        name local-fluentd
        host 127.0.0.1
        port 24226
    </server>
</match>
```

