### PR TITLE
Failed to read long GCP JSON as json_key by Errno::ENAMETOOLONG error

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -287,12 +287,14 @@ module Fluent
         json_key = @auth_options[:json_key]
 
         begin
+          JSON.parse(json_key)
+          key = StringIO.new(json_key)
+          Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: key, scope: @scope)
+        rescue JSON::ParserError
+          key = json_key
           File.open(json_key) do |f|
             Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: f, scope: @scope)
           end
-        rescue Errno::ENOENT
-          key = StringIO.new(json_key)
-          Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: key, scope: @scope)
         end
       end
 

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -145,7 +145,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
   end
 
   def test_configure_auth_json_key_as_string
-    json_key = '{"private_key": "X", "client_email": "xxx@developer.gserviceaccount.com"}'
+    json_key = '{"private_key": "X", "client_email": "' + 'x' * 255 + '@developer.gserviceaccount.com"}'
     json_key_io = StringIO.new(json_key)
     mock(StringIO).new(json_key) { json_key_io }
     authorization = Object.new


### PR DESCRIPTION
Hi,

PROBLEM:

I met exception below, and it looks GCP json is sometimes  longer than 255 bytes, and such case fluent-plugin-bigquery doesn't works at all. This look like a side effect of [this PR](https://github.com/kaizenplatform/fluent-plugin-bigquery/pull/89).

```
2016-11-03 20:27:42 -0500 [warn]: temporarily failed to flush the buffer. next_retry=2016-11-03 20:27:44 -0500 error_class="Errno::ENAMETOOLONG" error="Filename too long @ rb_sysopen - {\“ JSON_KEY_INFO_HERE \"}" plugin_id="object:2b11477755f0"
```

SOLUTION:
At first, try to parse json_key as JSON. If failed to parse it as JSON, next use json_key as file path. 

