### PR TITLE
insert retry when server error with status code 500 and 503

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -139,7 +139,7 @@ module Fluent
         reason = e.respond_to?(:reason) ? e.reason : nil
         log.error "tabledata.insertAll API", project_id: project, dataset: dataset, table: table_id, code: e.status_code, message: e.message, reason: reason
 
-        if RETRYABLE_ERROR_REASON.include?(reason)
+        if RETRYABLE_ERROR_REASON.include?(reason) || (e.is_a?(Google::Apis::ServerError) && [500, 503].include?(e.status_code))
           raise RetryableError.new(nil, e)
         else
           raise UnRetryableError.new(nil, e)

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -923,10 +923,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       skip_invalid_rows: false,
       ignore_unknown_values: false
     }, {options: {timeout_sec: nil, open_timeout_sec: 60}}) do
-      ex = Google::Apis::ServerError.new("error")
-      def ex.reason
-        "backendError"
-      end
+      ex = Google::Apis::ServerError.new("error", status_code: 500)
       raise ex
     end
 
@@ -971,7 +968,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       skip_invalid_rows: false,
       ignore_unknown_values: false
     }, {options: {timeout_sec: nil, open_timeout_sec: 60}}) do
-      ex = Google::Apis::ServerError.new("error")
+      ex = Google::Apis::ServerError.new("error", status_code: 501)
       def ex.reason
         "invalid"
       end


### PR DESCRIPTION
This pull request enable retry when BigQuery API response server error with status code of 500 and 503.

# Problem

On July 10th, 2016, we got [BigQuery Streaming API Incident](https://status.cloud.google.com/incident/bigquery/18022). At that moment, fluent-plugni-bigquery did not retry when streaming insert was executed. 

The following is one of the error.

```
2016-11-09 10:46:03 +0900 [error]: tabledata.insertAll API project_id="xxx" dataset="xxx" table="action_access_20161109" code=503 message="Server error" reason=nil
```

Google::Apis::ServerError does not response reason because there is no such attribute (If we investigate into @body field, there is reason inside of errors. However, the reason is not for that property.)

# Solution

To mitigate the issue, I implement to retry insert when it gets status code 500 or 503. These codes represent BigQuery API has issue. Thus, retry is suitable for these codes.