### PR TITLE
Support `convert_hash_to_json` on load method

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -434,6 +434,10 @@ module Fluent
           record = replace_record_key(record)
         end
 
+        if @convert_hash_to_json
+          record = convert_hash_to_json(record)
+        end
+
         buf = String.new
         row = @fields.format(@add_time_field.call(record, time))
         unless row.empty?


### PR DESCRIPTION
The `convert_hash_to_json` option is not available on load method. This PR fixes it.