### PR TITLE
Fix date partitioned table auto creation when use with time_slice suffix

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -25,6 +25,7 @@ module Fluent
         create_table_retry_limit = 3
         create_table_retry_wait = 1
         create_table_retry_count = 0
+        table_id = safe_table_id(table_id)
 
         begin
           definition = {
@@ -253,6 +254,10 @@ module Fluent
 
       def get_auth_from_application_default
         Google::Auth.get_application_default([@scope])
+      end
+
+      def safe_table_id(table_id)
+        table_id.gsub(/\$\d+$/, "")
       end
     end
   end


### PR DESCRIPTION
If user want to control time partitioned table segment with `time_slice_format`, current `auto_create` cannot support it.

I think that this way is not best but this is relatively good in current API.

refs. #101 