### PR TITLE
Make `convert_hash_to_json` deprecated.

### DIFF
--- a/lib/fluent/plugin/bigquery/schema.rb
+++ b/lib/fluent/plugin/bigquery/schema.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 module Fluent
   module BigQuery
     class FieldSchema
@@ -56,7 +58,11 @@ module Fluent
       end
 
       def format_one(value)
-        value.to_s
+        if value.is_a?(Hash) || value.is_a?(Array)
+          MultiJson.dump(value)
+        else
+          value.to_s
+        end
       end
     end
 

--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -259,6 +259,8 @@ module Fluent
       else
         @get_insert_id = nil
       end
+
+      warn "[DEPRECATION] `convert_hash_to_json` param is deprecated. If Hash value is inserted string field, plugin convert it to json automatically." if @convert_hash_to_json
     end
 
     def start

--- a/test/plugin/test_record_schema.rb
+++ b/test/plugin/test_record_schema.rb
@@ -154,6 +154,23 @@ class RecordSchemaTest < Test::Unit::TestCase
     )
   end
 
+  def test_format_one_convert_array_or_hash_to_json
+    fields = Fluent::BigQuery::RecordSchema.new("record")
+    fields.load_schema(base_schema, false)
+
+    time = Time.local(2016, 2, 7, 19, 0, 0).utc
+
+    formatted = fields.format_one({
+      "time" => time, "tty" => ["tty1", "tty2", "tty3"], "pwd" => "/home", "user" => {name: "joker1007", uid: 10000}, "argv" => ["foo", 42]
+    })
+    assert_equal(
+      formatted,
+      {
+        "time" => time.strftime("%Y-%m-%d %H:%M:%S.%6L %:z"), "tty" => MultiJson.dump(["tty1", "tty2", "tty3"]), "pwd" => "/home", "user" => MultiJson.dump({name: "joker1007", uid: 10000}), "argv" => ["foo", "42"]
+      }
+    )
+  end
+
   def test_format_one_with_extra_column
     fields = Fluent::BigQuery::RecordSchema.new("record")
     fields.load_schema(base_schema, false)


### PR DESCRIPTION
Instead of it, StringFieldSchema class converts Hash or Array to JSON
automatically.

I want to remove `convert_hash_to_json` config. Because this is redundant and brings complexity.