### PR TITLE
Retry to insert rows also in case of code 502, 504

### DIFF
--- a/lib/fluent/plugin/bigquery/errors.rb
+++ b/lib/fluent/plugin/bigquery/errors.rb
@@ -4,7 +4,7 @@ module Fluent
     class Error < StandardError
       RETRYABLE_ERROR_REASON = %w(backendError internalError rateLimitExceeded tableUnavailable).freeze
       RETRYABLE_INSERT_ERRORS_REASON = %w(timeout).freeze
-      RETRYABLE_STATUS_CODE = [500, 502, 503]
+      RETRYABLE_STATUS_CODE = [500, 502, 503, 504]
 
       class << self
         def wrap(google_api_error, message = nil, force_unretryable: false)

--- a/lib/fluent/plugin/bigquery/errors.rb
+++ b/lib/fluent/plugin/bigquery/errors.rb
@@ -4,7 +4,7 @@ module Fluent
     class Error < StandardError
       RETRYABLE_ERROR_REASON = %w(backendError internalError rateLimitExceeded tableUnavailable).freeze
       RETRYABLE_INSERT_ERRORS_REASON = %w(timeout).freeze
-      RETRYABLE_STATUS_CODE = [500, 503]
+      RETRYABLE_STATUS_CODE = [500, 502, 503]
 
       class << self
         def wrap(google_api_error, message = nil, force_unretryable: false)

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -770,61 +770,61 @@ class BigQueryOutputTest < Test::Unit::TestCase
     ]
 
     data_input.each do |d|
-    driver = create_driver(<<-CONFIG)
-      table foo
-      email foo@bar.example
-      private_key_path /path/to/key
-      project yourproject_id
-      dataset yourdataset_id
+      driver = create_driver(<<-CONFIG)
+        table foo
+        email foo@bar.example
+        private_key_path /path/to/key
+        project yourproject_id
+        dataset yourdataset_id
 
-      <inject>
-      time_format %s
-      time_key  time
-      </inject>
+        <inject>
+        time_format %s
+        time_key  time
+        </inject>
 
-      schema [
-        {"name": "time", "type": "INTEGER"},
-        {"name": "status", "type": "INTEGER"},
-        {"name": "bytes", "type": "INTEGER"},
-        {"name": "vhost", "type": "STRING"},
-        {"name": "path", "type": "STRING"},
-        {"name": "method", "type": "STRING"},
-        {"name": "protocol", "type": "STRING"},
-        {"name": "agent", "type": "STRING"},
-        {"name": "referer", "type": "STRING"},
-        {"name": "remote", "type": "RECORD", "fields": [
-          {"name": "host", "type": "STRING"},
-          {"name": "ip", "type": "STRING"},
-          {"name": "user", "type": "STRING"}
-        ]},
-        {"name": "requesttime", "type": "FLOAT"},
-        {"name": "bot_access", "type": "BOOLEAN"},
-        {"name": "loginsession", "type": "BOOLEAN"}
-      ]
-      <secondary>
-        type file
-        path error
-        utc
-      </secondary>
-    CONFIG
+        schema [
+          {"name": "time", "type": "INTEGER"},
+          {"name": "status", "type": "INTEGER"},
+          {"name": "bytes", "type": "INTEGER"},
+          {"name": "vhost", "type": "STRING"},
+          {"name": "path", "type": "STRING"},
+          {"name": "method", "type": "STRING"},
+          {"name": "protocol", "type": "STRING"},
+          {"name": "agent", "type": "STRING"},
+          {"name": "referer", "type": "STRING"},
+          {"name": "remote", "type": "RECORD", "fields": [
+            {"name": "host", "type": "STRING"},
+            {"name": "ip", "type": "STRING"},
+            {"name": "user", "type": "STRING"}
+          ]},
+          {"name": "requesttime", "type": "FLOAT"},
+          {"name": "bot_access", "type": "BOOLEAN"},
+          {"name": "loginsession", "type": "BOOLEAN"}
+        ]
+        <secondary>
+          type file
+          path error
+          utc
+        </secondary>
+      CONFIG
 
-    entry = {a: "b"}
-    writer = stub_writer(driver)
-    mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', {
-      rows: [{json: hash_including(entry)}],
-      skip_invalid_rows: false,
-      ignore_unknown_values: false
-    }, {options: {timeout_sec: nil, open_timeout_sec: 60}}) do
-      ex = Google::Apis::ServerError.new("error", status_code: d["status_code"])
-      raise ex
-    end
+      entry = {a: "b"}
+      writer = stub_writer(driver)
+      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', {
+        rows: [{json: hash_including(entry)}],
+        skip_invalid_rows: false,
+        ignore_unknown_values: false
+      }, {options: {timeout_sec: nil, open_timeout_sec: 60}}) do
+        ex = Google::Apis::ServerError.new("error", status_code: d["status_code"])
+        raise ex
+      end
 
-    assert_raise(Fluent::BigQuery::RetryableError) do
-      driver.run do
-        driver.feed("tag", Time.now.to_i, {"a" => "b"})
+      assert_raise(Fluent::BigQuery::RetryableError) do
+        driver.run do
+          driver.feed("tag", Time.now.to_i, {"a" => "b"})
+        end
       end
     end
-  end
   end
 
   def test_write_with_not_retryable_error

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -763,6 +763,13 @@ class BigQueryOutputTest < Test::Unit::TestCase
   end
 
   def test_write_with_retryable_error
+    data_input = [
+      { "status_code" => 500  },
+      { "status_code" => 502  },
+      { "status_code" => 503  },
+    ]
+
+    data_input.each do |d|
     driver = create_driver(<<-CONFIG)
       table foo
       email foo@bar.example
@@ -808,7 +815,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       skip_invalid_rows: false,
       ignore_unknown_values: false
     }, {options: {timeout_sec: nil, open_timeout_sec: 60}}) do
-      ex = Google::Apis::ServerError.new("error", status_code: 500)
+      ex = Google::Apis::ServerError.new("error", status_code: d["status_code"])
       raise ex
     end
 
@@ -817,6 +824,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
         driver.feed("tag", Time.now.to_i, {"a" => "b"})
       end
     end
+  end
   end
 
   def test_write_with_not_retryable_error

--- a/test/plugin/test_out_bigquery.rb
+++ b/test/plugin/test_out_bigquery.rb
@@ -767,6 +767,7 @@ class BigQueryOutputTest < Test::Unit::TestCase
       { "status_code" => 500  },
       { "status_code" => 502  },
       { "status_code" => 503  },
+      { "status_code" => 504  },
     ]
 
     data_input.each do |d|


### PR DESCRIPTION
In our production environment, a response with 502 code has occurred dozens to hundreds times a day.

Also, it occurred more frequently at BigQuery failure of approximately 2017-03-13 10:22 ~ 10:52 (PDT).

- ref. https://status.cloud.google.com/incident/bigquery/18026

```
❯❯❯ grep error /tmp/20170314-app-502.txt | head -n10
 ** [out :: 10.0.8.244] 2017-03-14 02:11:35 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="imp" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:15:26 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="ad_20170314" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:15:26 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="imp" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:32:51 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="imp_20170314" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:32:53 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="rtb" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:34:54 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="imp" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:34:56 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="rtb" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:34:57 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="imp" code=502 message="Server error" reason=nil
 ** [out :: 10.0.8.244] 2017-03-14 02:34:57 +0900 [error]: bigquery/writer.rb:102:rescue in insert_rows: tabledata.insertAll API project_id="turnkey-conduit-708" dataset="hogehoge" table="media_auth_log" code=502 message="Server error" reason=nil
```

502 code was retried at least at v0.2.6. When using v0.2.6, 502 code retry was done without any problem. So we want this version to support the retry.

- ref. https://github.com/kaizenplatform/fluent-plugin-bigquery/blob/v0.2.6/lib/fluent/plugin/out_bigquery.rb#L280

For reference, we are using a custom gem with this support for several days in production, but all retry has succeeded without a single failure.

Also, I thought that 504 could be added to support for the same reason.

