### PR TITLE
Add missing require

### DIFF
--- a/lib/fluent/plugin/out_bigquery.rb
+++ b/lib/fluent/plugin/out_bigquery.rb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+require 'fluent/plugin/output'
+
 require 'fluent/plugin/bigquery/version'
 
 require 'fluent/plugin/bigquery/helper'


### PR DESCRIPTION
Because Fluentd core developers recommends that load libraries
explicitly.
See also fluent-plugin under fluent organization.