### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Use placeholder.
   @type bigquery
 
   ...
-  table   accesslog$%Y%m%d
+  table   accesslog_%Y%m%d
 
   <buffer time>
     timekey 1d


### PR DESCRIPTION
In BigQuery table name, dollar `$` can not use.
Perhaps, look like to me that had been forgotten to replace the placeholder symbols.