### PR TITLE
Fix "undefined method `empty?' for nil:NilClass"

### DIFF
--- a/lib/fluent/plugin/out_bigquery_base.rb
+++ b/lib/fluent/plugin/out_bigquery_base.rb
@@ -184,7 +184,7 @@ module Fluent
             table_schema.load_schema(schema)
             @fetched_schemas["#{project}.#{dataset}.#{table_id}"] = table_schema
           else
-            if @fetched_schemas["#{project}.#{dataset}.#{table_id}"].empty?
+            if @fetched_schemas["#{project}.#{dataset}.#{table_id}"].nil?
               raise "failed to fetch schema from bigquery"
             else
               log.warn "#{table_id} uses previous schema"


### PR DESCRIPTION
"undefined method `empty?' for nil:NilClass" error occurs if the specified table is not found. I've fixed it.
It seems to be a regression introduced in https://github.com/kaizenplatform/fluent-plugin-bigquery/pull/117.

## Before

```
% bundle exe fluentd -c fluent.conf
2018-07-24 21:44:33 +0900 [info]: parsing config file is succeeded path="fluent.conf"
2018-07-24 21:44:34 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:44:34 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:44:34 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type dummy
    auto_increment_key "id"
    tag "bq.dummy"
  </source>
  <match bq.**>
    @type bigquery_load
    auth_method json_key
    json_key xxxxxx
    project "bigquery-test-181907"
    dataset "test"
    table "bar"
    fetch_schema true
    <buffer>
      path "/tmp/fluentd-bq"
      flush_interval 1m
    </buffer>
  </match>
</ROOT>
2018-07-24 21:44:34 +0900 [info]: starting fluentd-1.2.2 pid=27010 ruby="2.5.0"
2018-07-24 21:44:34 +0900 [info]: spawn command to main:  cmdline=["/Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/bin/ruby", "-Eascii-8bit:ascii-8bit", "-rbundler/setup", "/Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bin/fluentd", "-c", "fluent.conf", "--under-supervisor"]
2018-07-24 21:44:35 +0900 [info]: gem 'fluentd' version '1.2.2'
2018-07-24 21:44:35 +0900 [info]: gem 'fluent-plugin-bigquery' version '2.0.0.beta'
2018-07-24 21:44:35 +0900 [info]: adding match pattern="bq.**" type="bigquery_load"
2018-07-24 21:44:36 +0900 [info]: adding source type="dummy"
2018-07-24 21:44:36 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:44:36 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:44:36 +0900 [info]: #0 starting fluentd worker pid=27041 ppid=27010 worker=0
2018-07-24 21:44:36 +0900 [info]: #0 fluentd worker is now running worker=0
2018-07-24 21:44:37 +0900 [error]: #0 tables.get API project_id="bigquery-test-181907" dataset="test" table="bar" code=404 message="notFound: Not found: Table bigquery-test-181907:test.bar"
2018-07-24 21:44:37 +0900 [warn]: #0 emit transaction failed: error_class=NoMethodError error="undefined method `empty?' for nil:NilClass" location="/Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_base.rb:187:in `fetch_schema'" tag="bq.dummy"
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_base.rb:187:in `fetch_schema'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_base.rb:155:in `format'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_load.rb:61:in `format'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:959:in `block in handle_stream_simple'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/event.rb:107:in `each'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:958:in `handle_stream_simple'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:844:in `execute_chunking'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:774:in `emit_buffered'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/event_router.rb:96:in `emit_stream'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/event_router.rb:87:in `emit'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:111:in `block in emit'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:111:in `times'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:111:in `emit'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:96:in `run'
  2018-07-24 21:44:37 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```

## After

```
% bundle exec fluentd -c fluent.conf
2018-07-24 21:50:09 +0900 [info]: parsing config file is succeeded path="fluent.conf"
2018-07-24 21:50:10 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:50:10 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:50:10 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type dummy
    auto_increment_key "id"
    tag "bq.dummy"
  </source>
  <match bq.**>
    @type bigquery_load
    auth_method json_key
    json_key xxxxxx
    project "bigquery-test-181907"
    dataset "test"
    table "bar"
    fetch_schema true
    <buffer>
      path "/tmp/fluentd-bq"
      flush_interval 1m
    </buffer>
  </match>
</ROOT>
2018-07-24 21:50:10 +0900 [info]: starting fluentd-1.2.2 pid=27300 ruby="2.5.0"
2018-07-24 21:50:10 +0900 [info]: spawn command to main:  cmdline=["/Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/bin/ruby", "-Eascii-8bit:ascii-8bit", "-rbundler/setup", "/Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bin/fluentd", "-c", "fluent.conf", "--under-supervisor"]
2018-07-24 21:50:12 +0900 [info]: gem 'fluentd' version '1.2.2'
2018-07-24 21:50:12 +0900 [info]: gem 'fluent-plugin-bigquery' version '2.0.0.beta'
2018-07-24 21:50:12 +0900 [info]: adding match pattern="bq.**" type="bigquery_load"
2018-07-24 21:50:13 +0900 [info]: adding source type="dummy"
2018-07-24 21:50:13 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:50:13 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2018-07-24 21:50:13 +0900 [info]: #0 starting fluentd worker pid=27331 ppid=27300 worker=0
2018-07-24 21:50:13 +0900 [info]: #0 fluentd worker is now running worker=0
2018-07-24 21:50:14 +0900 [error]: #0 tables.get API project_id="bigquery-test-181907" dataset="test" table="bar" code=404 message="notFound: Not found: Table bigquery-test-181907:test.bar"
2018-07-24 21:50:14 +0900 [warn]: #0 emit transaction failed: error_class=RuntimeError error="failed to fetch schema from bigquery" location="/Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_base.rb:187:in `fetch_schema'" tag="bq.dummy"
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_base.rb:187:in `fetch_schema'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_base.rb:155:in `format'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/kaizenplatform/fluent-plugin-bigquery/lib/fluent/plugin/out_bigquery_load.rb:61:in `format'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:959:in `block in handle_stream_simple'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/event.rb:107:in `each'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:958:in `handle_stream_simple'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:844:in `execute_chunking'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:774:in `emit_buffered'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/event_router.rb:96:in `emit_stream'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/event_router.rb:87:in `emit'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:111:in `block in emit'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:111:in `times'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:111:in `emit'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/in_dummy.rb:96:in `run'
  2018-07-24 21:50:14 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```