### PR TITLE
Consider the case when `stats` is nil

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -228,9 +228,10 @@ module Fluent
           end
         end
 
+        # `stats` can be nil if we receive a warning like "Warning: Load job succeeded with data imported, however statistics may be lost due to internal error."
         stats = response.statistics.load
         duration = (response.statistics.end_time - response.statistics.creation_time) / 1000.0
-        log.debug "load job finished", id: job_id, state: response.status.state, input_file_bytes: stats.input_file_bytes, input_files: stats.input_files, output_bytes: stats.output_bytes, output_rows: stats.output_rows, bad_records: stats.bad_records, duration: duration.round(2), project_id: project, dataset: dataset, table: table_id
+        log.debug "load job finished", id: job_id, state: response.status.state, input_file_bytes: stats&.input_file_bytes, input_files: stats&.input_files, output_bytes: stats&.output_bytes, output_rows: stats&.output_rows, bad_records: stats&.bad_records, duration: duration.round(2), project_id: project, dataset: dataset, table: table_id
         @num_errors_per_chunk.delete(chunk_id_hex)
       end
 


### PR DESCRIPTION
fluent-plugin-bigquery sometimes raises an error like below:

```
2018-09-04 12:24:16 +0000 [error]: #1 [PLUGIN_ID] job.load API (rows) job_id="OUR_PROJECT_ID:US.fluentd_job_de1540f9ff18d52220ccd3e99ddf4909ca09885f" project_id="OUR_PROJECT_ID" dataset="OUR_DATABASE" table="OUR_TABLE" message="Warning: Load job succeeded with data imported, however statistics may be lost due to internal error." reason=nil
 2018-09-04 12:24:16 +0000 [error]: #1 [PLUGIN_ID] unexpected error while polling error_class=NoMethodError error="undefined method `input_file_bytes' for nil:NilClass"
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/bundler/gems/fluent-plugin-bigquery-ecb91f3237d1/lib/fluent/plugin/bigquery/writer.rb:233:in `commit_load_job'
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/bundler/gems/fluent-plugin-bigquery-ecb91f3237d1/lib/fluent/plugin/out_bigquery_load.rb:158:in `poll'
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/timer.rb:80:in `on_timer'
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/gems/cool.io-1.5.3/lib/cool.io/loop.rb:88:in `run_once'
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/gems/cool.io-1.5.3/lib/cool.io/loop.rb:88:in `run'
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/event_loop.rb:93:in `block in start'
   2018-09-04 12:24:16 +0000 [error]: #1 /path/to/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```

It seems that`stats` can be nil if we receive a warning like "Warning: Load job succeeded with data imported, however statistics may be lost due to internal error.".