### PR TITLE
Deprecate "table created" error

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -312,7 +312,7 @@ module Fluent
             type: @options[:time_partitioning_type].to_s.upcase,
             field: @options[:time_partitioning_field] ? @options[:time_partitioning_field].to_s : nil,
             expiration_ms: @options[:time_partitioning_expiration] ? @options[:time_partitioning_expiration] * 1000 : nil
-          }.compact
+          }.reject { |_, v| v.nil? }
         else
           @time_partitioning
         end

--- a/lib/fluent/plugin/out_bigquery_insert.rb
+++ b/lib/fluent/plugin/out_bigquery_insert.rb
@@ -96,14 +96,8 @@ module Fluent
       end
 
       def insert(project, dataset, table_id, rows, schema, template_suffix)
-        writer.insert_rows(project, dataset, table_id, rows, template_suffix: template_suffix)
+        writer.insert_rows(project, dataset, table_id, rows, schema, template_suffix: template_suffix)
       rescue Fluent::BigQuery::Error => e
-        if @auto_create_table && e.status_code == 404 && /Not Found: Table/i =~ e.message
-          # Table Not Found: Auto Create Table
-          writer.create_table(project, dataset, table_id, schema)
-          raise "table created. send rows next time."
-        end
-
         raise if e.retryable?
 
         if @secondary

--- a/test/plugin/test_out_bigquery_insert.rb
+++ b/test/plugin/test_out_bigquery_insert.rb
@@ -355,7 +355,14 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      mock(writer).create_table('yourproject_id', 'yourdataset_id', 'foo', driver.instance.instance_variable_get(:@table_schema))
+      mock(writer.client).insert_table('yourproject_id', 'yourdataset_id', {
+        table_reference: {
+          table_id: 'foo',
+        },
+        schema: {
+          fields: driver.instance.instance_variable_get(:@table_schema).to_a,
+        },
+      }, {})
     end
 
     assert_raise(RuntimeError) do
@@ -422,7 +429,19 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      mock(writer).create_table('yourproject_id', 'yourdataset_id', 'foo', driver.instance.instance_variable_get(:@table_schema))
+      mock(writer.client).insert_table('yourproject_id', 'yourdataset_id', {
+        table_reference: {
+          table_id: 'foo',
+        },
+        schema: {
+          fields: driver.instance.instance_variable_get(:@table_schema).to_a,
+        },
+        time_partitioning: {
+          type: 'DAY',
+          field: 'time',
+          expiration_ms: 3600000,
+        },
+      }, {})
     end
 
     assert_raise(RuntimeError) do


### PR DESCRIPTION
This PR changes the behavior not to raise so many errors when `auto_create_table` is set to `true`.
Fluentd sometimes drops all chunks without transition to secondary if so many errors occur.
See https://github.com/fluent/fluentd/issues/2123 for more details.
