### PR TITLE
delete & for syntaxerror

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -214,7 +214,7 @@ module Fluent
         # `stats` can be nil if we receive a warning like "Warning: Load job succeeded with data imported, however statistics may be lost due to internal error."
         stats = response.statistics.load
         duration = (response.statistics.end_time - response.statistics.creation_time) / 1000.0
-        log.debug "load job finished", id: job_id, state: response.status.state, input_file_bytes: stats&.input_file_bytes, input_files: stats&.input_files, output_bytes: stats&.output_bytes, output_rows: stats&.output_rows, bad_records: stats&.bad_records, duration: duration.round(2), project_id: project, dataset: dataset, table: table_id
+        log.debug "load job finished", id: job_id, state: response.status.state, input_file_bytes: stats.input_file_bytes, input_files: stats.input_files, output_bytes: stats.output_bytes, output_rows: stats.output_rows, bad_records: stats.bad_records, duration: duration.round(2), project_id: project, dataset: dataset, table: table_id
         @num_errors_per_chunk.delete(chunk_id_hex)
       end
 


### PR DESCRIPTION
Can not load `bigquery/writer.rb`.
Can you check my pullrequest?

```
Reloading td-agent: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require': /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-bigquery-2.1.0/lib/fluent/plugin/bigquery/writer.rb:219: syntax error, unexpected '.' (SyntaxError)
...tate, input_file_bytes: stats&.input_file_bytes, input_files...
...                               ^
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-bigquery-2.1.0/lib/fluent/plugin/bigquery/writer.rb:219: syntax error, unexpected ',', expecting keyword_end
...s, duration: duration.round(2), project_id: project, dataset...
...                               ^
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-bigquery-2.1.0/lib/fluent/plugin/out_bigquery_base.rb:8:in `<top (required)>'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:133:in `require'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-bigquery-2.1.0/lib/fluent/plugin/out_bigquery_insert.rb:1:in `<top (required)>'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/registry.rb:102:in `block in search'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/registry.rb:99:in `each'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/registry.rb:99:in `search'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/registry.rb:44:in `lookup'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin.rb:146:in `new_impl'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin.rb:104:in `new_output'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin/multi_output.rb:72:in `block in configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin/multi_output.rb:63:in `each'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin/multi_output.rb:63:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin/out_copy.rb:36:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/plugin.rb:164:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/agent.rb:130:in `add_match'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/agent.rb:72:in `block in configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/agent.rb:64:in `each'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/agent.rb:64:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/root_agent.rb:112:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/engine.rb:131:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/engine.rb:96:in `run_configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/supervisor.rb:795:in `run_configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/supervisor.rb:579:in `dry_run'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/supervisor.rb:566:in `dry_run_cmd'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/supervisor.rb:501:in `run_supervisor'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/lib/fluent/command/fluentd.rb:310:in `<top (required)>'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-1.2.0/bin/fluentd:8:in `<top (required)>'
	from /opt/td-agent/embedded/bin/fluentd:23:in `load'
	from /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
	from /usr/sbin/td-agent:7:in `load'
	from /usr/sbin/td-agent:7:in `<main>'
```