### PR TITLE
Add numeric field support

### DIFF
--- a/lib/fluent/plugin/bigquery/schema.rb
+++ b/lib/fluent/plugin/bigquery/schema.rb
@@ -86,6 +86,16 @@ module Fluent
       end
     end
 
+    class NumericFieldSchema < FieldSchema
+      def type
+        :numeric
+      end
+
+      def format_one(value)
+        value.to_s
+      end
+    end
+
     class BooleanFieldSchema < FieldSchema
       def type
         :boolean
@@ -169,6 +179,7 @@ module Fluent
         string: StringFieldSchema,
         integer: IntegerFieldSchema,
         float: FloatFieldSchema,
+        numeric: NumericFieldSchema,
         boolean: BooleanFieldSchema,
         timestamp: TimestampFieldSchema,
         date: DateFieldSchema,

--- a/test/plugin/test_record_schema.rb
+++ b/test/plugin/test_record_schema.rb
@@ -27,6 +27,11 @@ class RecordSchemaTest < Test::Unit::TestCase
         "name" => "argv",
         "type" => "STRING",
         "mode" => "REPEATED"
+      },
+      {
+        "name" => "utilisation",
+        "type" => "NUMERIC",
+        "mode" => "NULLABLE"
       }
     ]
   end
@@ -57,6 +62,11 @@ class RecordSchemaTest < Test::Unit::TestCase
         "name" => "argv",
         "type" => "STRING",
         "mode" => "REPEATED"
+      },
+      {
+        "name" => "utilisation",
+        "type" => "NUMERIC",
+        "mode" => "NULLABLE"
       },
       {
         "name" => "new_column",
@@ -93,6 +103,11 @@ class RecordSchemaTest < Test::Unit::TestCase
         "type" => "STRING",
         "mode" => "REPEATED"
       },
+      {
+        "name" => "utilisation",
+        "type" => "NUMERIC",
+        "mode" => "NULLABLE"
+      }
     ]
   end
 
@@ -142,12 +157,12 @@ class RecordSchemaTest < Test::Unit::TestCase
     time = Time.local(2016, 2, 7, 19, 0, 0).utc
 
     formatted = fields.format_one({
-      "time" => time, "tty" => ["tty1", "tty2", "tty3"], "pwd" => "/home", "user" => {name: "joker1007", uid: 10000}, "argv" => ["foo", 42]
+      "time" => time, "tty" => ["tty1", "tty2", "tty3"], "pwd" => "/home", "user" => {name: "joker1007", uid: 10000}, "argv" => ["foo", 42], "utilisation" => "0.837"
     })
     assert_equal(
       formatted,
       {
-        "time" => time.strftime("%Y-%m-%d %H:%M:%S.%6L %:z"), "tty" => MultiJson.dump(["tty1", "tty2", "tty3"]), "pwd" => "/home", "user" => MultiJson.dump({name: "joker1007", uid: 10000}), "argv" => ["foo", "42"]
+        "time" => time.strftime("%Y-%m-%d %H:%M:%S.%6L %:z"), "tty" => MultiJson.dump(["tty1", "tty2", "tty3"]), "pwd" => "/home", "user" => MultiJson.dump({name: "joker1007", uid: 10000}), "argv" => ["foo", "42"], "utilisation" => "0.837"
       }
     )
   end


### PR DESCRIPTION
Adds support for `NUMERIC` type in BigQuery table schemas